### PR TITLE
Add support for icons in command list, use common SSH connection, add support for mDNS service resolve

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,9 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
+    dexOptions {
+        jumboMode true
+    }
 }
 
 apply plugin: 'com.neenbedankt.android-apt'
@@ -42,7 +45,11 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.4.2'
-    compile 'com.jcraft:jsch:0.1.51'
+    compile 'com.jcraft:jsch:0.1.54'
+    compile 'com.madgag.spongycastle:core:1.54.0.0'
+    compile 'com.madgag.spongycastle:prov:1.54.0.0'
+    compile 'com.madgag.spongycastle:pkix:1.54.0.0'
+    compile 'com.madgag.spongycastle:pg:1.54.0.0'
     compile 'com.github.tony19:logback-android-core:1.1.1-6'
     compile 'com.github.tony19:logback-android-classic:1.1.1-6'
     compile 'org.slf4j:slf4j-api:1.7.21'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <application
         android:name="it.skarafaz.mercury.MercuryApplication"

--- a/app/src/main/assets/help/index.html
+++ b/app/src/main/assets/help/index.html
@@ -56,6 +56,16 @@
     "background" : true,
     "multiple" : false,
     "silent" : true
+  }, {
+    "name" : "Webcam",
+    "icon" : "webcam.png",
+    "cmd" : "ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:2 -frames 1 -loglevel 24 -y /tmp/webcam.png",
+    "wait" : true,
+    "background" : true,
+    "multiple" : false,
+    "silent" : true
+    "download" : "/tmp/webcam.png",
+    "view" : true
   } ]
 }
             </pre>
@@ -170,6 +180,12 @@
                     <td>The command itself. Mandatory.</td>
                 </tr>
                 <tr>
+                    <td><code>download</code></td>
+                    <td>string</td>
+                    <td>Path of file to download from server after sending (<code>wait : false</code>) respectively
+                        executing (<code>wait : true</code>)command. Optional.</td>
+                </tr>
+                <tr>
                     <td><code>confirm</code></td>
                     <td>boolean</td>
                     <td>Ask for confirmation before sending command. Optional, defaults to <code>false</code>.</td>
@@ -177,7 +193,8 @@
                 <tr>
                     <td><code>wait</code></td>
                     <td>boolean</td>
-                    <td>Ask for confirmation before sending command. Optional, defaults to <code>false</code>.</td>
+                    <td>Wait for termination after sending command and display error, if result code is nonzero.
+                        Optional, defaults to <code>false</code>.</td>
                 </tr>
                 <tr>
                     <td><code>background</code></td>
@@ -200,6 +217,12 @@
                     <td><code>silent</code></td>
                     <td>boolean</td>
                     <td>Show toast message only on error. Optional, defaults to <code>false</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>view</code></td>
+                    <td>boolean</td>
+                    <td>Display downloaded file using default application. Requires <code>download</code>. Optional,
+                        defaults to <code>false</code>.</td>
                 </tr>
                 </tbody>
             </table>

--- a/app/src/main/assets/help/index.html
+++ b/app/src/main/assets/help/index.html
@@ -24,14 +24,10 @@
             <p>Public key authentication is the preferred authentication method used by Mercury-SSH. If
                 public key authentication fails then a password will be prompted. You are free to embed the password in
                 the configuration file or type it each time you send a command (note that sudo commands will always
-                require
-                password in
-                order to be executed, even with public key authentication).</p>
-            <p>Mercury-SSH uses a self generated 2048
-                bit RSA key. You can <i>export the public key</i> to sdcard and manually copy it to your
-                server or let Mercury-SSH do this for you using the <i>send public key</i> feature (you still need
-                password
-                access to the target server to do this).</p>
+                require password in order to be executed, even with public key authentication).</p>
+            <p>Mercury-SSH uses a self generated 2048 bit RSA key by default. You can <i>export the public key</i> to
+                sdcard and manually copy it to your server or let Mercury-SSH do this for you using the <i>send public
+                key</i> feature (you still need password access to the target server to do this).</p>
             <h3>Writing a configuration file</h3>
             <p>Few lines of code are better than thousand words, so let's start with a sample configuration file:</p>
             <pre>
@@ -39,18 +35,27 @@
   "name" : "Server",
   "host" : "192.168.0.1",
   "port" : 22,
+  "mdnsname" : "server",
+  "mdnstype" : "_ssh._tcp",
   "user" : "user",
   "password" : "12345678",
+  "authtype" : "rsa4096",
   "nohupPath" : "/opt/bin/nohup",
   "commands" : [ {
+    "icon" : "apache.png",
     "name" : "Restart apache",
     "sudo" : true,
     "cmd" : "service apache2 restart",
     "confirm" : true
   }, {
+    "icon" : "rsync.png",
     "name" : "Rsync",
     "sudo" : true,
     "cmd" : "rsync -a /src/ /dst/"
+    "wait" : true,
+    "background" : true,
+    "multiple" : false,
+    "silent" : true
   } ]
 }
             </pre>
@@ -75,12 +80,24 @@
                 <tr>
                     <td><code>host</code></td>
                     <td>string</td>
-                    <td>Target hostname or IP address. Mandatory.</td>
+                    <td>Target hostname or IP address. Mandatory unless <code>mdnsname</code> is provided.</td>
                 </tr>
                 <tr>
                     <td><code>port</code></td>
                     <td>integer</td>
                     <td>Target port (1-65535). Optional, defaults to <code>22</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>mdnsname</code></td>
+                    <td>string</td>
+                    <td>Target multicast dns service name. Mandatory unless <code>host</code>code> is provided. Use
+                        <code>avahi-browse -rt _ssh._tcp</code> for checking service names and their corresponding
+                        addresses and ports.</td>
+                </tr>
+                <tr>
+                    <td><code>mdnstype</code></td>
+                    <td>string</td>
+                    <td>Target multicast dns service type. Optional, defaults to <code>_ssh._tcp</code></td>
                 </tr>
                 <tr>
                     <td><code>user</code></td>
@@ -91,6 +108,18 @@
                     <td><code>password</code></td>
                     <td>string</td>
                     <td>Login password. Optional.</td>
+                </tr>
+                <tr>
+                    <td><code>authtype</code></td>
+                    <td>string</td>
+                    <td>Type of SSH key used for authentication. Supported values: <code>dsa512</code>,
+                        <code>dsa1024</code>, <code>dsa2048</code>, <code>dsa4096</code>, <code>dsa8192</code>,
+                        <code>ecdsa128</code>, <code>ecdsa256</code>, <code>ecdsa521</code>, <code>rsa512</code>,
+                        <code>rsa1024</code>, <code>rsa2048</code>, <code>rsa4096</code>, <code>rsa8192</code>.
+                        <code>dsa</code> is equivalent to <code>dsa2048</code>, <code>rsa</code> to <code>rsa2048
+                        </code>, and <code>ecdsa</code> to <code>ecdsa512</code>. Optional,
+                        defaults to <code>rsa2048</code>.
+                    </td>
                 </tr>
                 <tr>
                     <td><code>nohupPath</code></td>
@@ -120,6 +149,11 @@
                 </thead>
                 <tbody>
                 <tr>
+                    <td><code>icon</code></td>
+                    <td>string</td>
+                    <td>Name of icon file in folder MercurySSH (shown before label). Optional.</td>
+                </tr>
+                <tr>
                     <td><code>name</code></td>
                     <td>string</td>
                     <td>Friendly name (used as label). Optional, defaults to <code>"Command"</code>.</td>
@@ -139,6 +173,33 @@
                     <td><code>confirm</code></td>
                     <td>boolean</td>
                     <td>Ask for confirmation before sending command. Optional, defaults to <code>false</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>wait</code></td>
+                    <td>boolean</td>
+                    <td>Ask for confirmation before sending command. Optional, defaults to <code>false</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>background</code></td>
+                    <td>boolean</td>
+                    <td>If true, command runs in background and progress bar is shown inside command list. Thus other
+                        commands may be started while this command is running. Otherwise progress bar is shown in
+                        dialog. Optional, defaults to <code>false</code>.
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>multiple</code></td>
+                    <td>boolean</td>
+                    <td>If true, the same command may be executed several times in parallel. The number of running
+                        commands is shown in the progress bar. Otherwise the command only may be started when no
+                        other instance of the same command is running. Requires <code>background : true</code>.
+                        Optional, defaults to <code>false</code>.
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>silent</code></td>
+                    <td>boolean</td>
+                    <td>Show toast message only on error. Optional, defaults to <code>false</code>.</td>
                 </tr>
                 </tbody>
             </table>

--- a/app/src/main/assets/help/index.html
+++ b/app/src/main/assets/help/index.html
@@ -66,6 +66,17 @@
     "silent" : true
     "download" : "/tmp/webcam.png",
     "view" : true
+  }, {
+    "name" : "Brightness",
+    "icon" : "display-brightness-symbolic.png",
+    "getcmd" : "dbus-send --print-reply=literal --session --dest=org.gnome.SettingsDaemon /org/gnome/SettingsDaemon/Power org.freedesktop.DBus.Properties.Get string:org.gnome.SettingsDaemon.Power.Screen string:Brightness | awk '{ print $3; }'",
+    "setcmd" : "dbus-send --print-reply --session --dest=org.gnome.SettingsDaemon.Power /org/gnome/SettingsDaemon/Power org.freedesktop.DBus.Properties.Set string:org.gnome.SettingsDaemon.Power.Screen string:Brightness variant:int32:${VALUE}",
+    "min" : 0,
+    "max" : 100,
+    "step" : 1,
+    "wait" : true,
+    "background" : true,
+    "silent" : true
   } ]
 }
             </pre>
@@ -144,7 +155,7 @@
                 <tr>
                     <td><code>commands</code></td>
                     <td>array</td>
-                    <td>An array of objects defining available commands for the server. Optional.</td>
+                    <td>An array of objects defining available commands and rulers for the server. Optional.</td>
                 </tr>
                 </tbody>
             </table>
@@ -223,6 +234,85 @@
                     <td>boolean</td>
                     <td>Display downloaded file using default application. Requires <code>download</code>. Optional,
                         defaults to <code>false</code>.</td>
+                </tr>
+                </tbody>
+            </table>
+            <h4>Ruler property summary</h4>
+            <table class="table">
+                <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Type</th>
+                    <th>Notes</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td><code>icon</code></td>
+                    <td>string</td>
+                    <td>Name of icon file in folder MercurySSH (shown before label). Optional.</td>
+                </tr>
+                <tr>
+                    <td><code>name</code></td>
+                    <td>string</td>
+                    <td>Friendly name (used as label). Optional, defaults to <code>"Command"</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>sudo</code></td>
+                    <td>boolean</td>
+                    <td>State if the command needs to be executed as root. Optional, defaults to <code>false</code>.
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>getcmd</code></td>
+                    <td>string</td>
+                    <td>The command for retrieving the ruler value. The command must print the value, an integer from
+                        <code>min</code> to <code>max</code>, on the first line of <code>stdout</code>. Mandatory.</td>
+                </tr>
+                <tr>
+                    <td><code>setcmd</code></td>
+                    <td>string</td>
+                    <td>The command for setting the ruler value. The value will be stored in the environment variable
+                        <code>VALUE</code> before executing <code>setcmd</code>. Mandatory.</td>
+                </tr>
+                <tr>
+                    <td><code>min</code></td>
+                    <td>integer</td>
+                    <td>The minimum ruler value. Optional, defaults to <code>0</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>max</code></td>
+                    <td>integer</td>
+                    <td>The maximum ruler value. Optional, defaults to <code>100</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>step</code></td>
+                    <td>integer</td>
+                    <td>The step between ruler two allowed ruler values. Optional, defaults to <code>1</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>confirm</code></td>
+                    <td>boolean</td>
+                    <td>Ask for confirmation before sending command. Optional, defaults to <code>false</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>wait</code></td>
+                    <td>boolean</td>
+                    <td>Wait for termination after sending command and display error, if result code is nonzero.
+                        Optional, defaults to <code>false</code>.</td>
+                </tr>
+                <tr>
+                    <td><code>background</code></td>
+                    <td>boolean</td>
+                    <td>If true, command runs in background and progress bar is shown inside command list. Thus other
+                        commands may be started while this command is running. Otherwise progress bar is shown in
+                        dialog. Optional, defaults to <code>false</code>.
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>silent</code></td>
+                    <td>boolean</td>
+                    <td>Show toast message only on error. Optional, defaults to <code>false</code>.</td>
                 </tr>
                 </tbody>
             </table>

--- a/app/src/main/java/it/skarafaz/mercury/activity/MainActivity.java
+++ b/app/src/main/java/it/skarafaz/mercury/activity/MainActivity.java
@@ -108,10 +108,12 @@ public class MainActivity extends MercuryActivity {
                 loadConfigFiles();
                 return true;
             case R.id.action_export_public_key:
+                if (server == null) return true;
                 exportPublicKey(ServerAuthType.valueOf(ServerAuthType.appendDefaultLength(server
                         .getAuthType())));
                 return true;
             case R.id.action_send_public_key:
+                if (server == null) return true;
                 new SshCommandPubKey(new SshServer(server, this)).start();
                 return true;
             case R.id.action_log:

--- a/app/src/main/java/it/skarafaz/mercury/activity/MainActivity.java
+++ b/app/src/main/java/it/skarafaz/mercury/activity/MainActivity.java
@@ -32,7 +32,10 @@ import it.skarafaz.mercury.manager.ConfigManager;
 import it.skarafaz.mercury.manager.ExportPublicKeyStatus;
 import it.skarafaz.mercury.manager.LoadConfigFilesStatus;
 import it.skarafaz.mercury.manager.SshManager;
+import it.skarafaz.mercury.model.Server;
+import it.skarafaz.mercury.model.ServerAuthType;
 import it.skarafaz.mercury.ssh.SshCommandPubKey;
+import it.skarafaz.mercury.ssh.SshServer;
 
 public class MainActivity extends MercuryActivity {
     private static final int STORAGE_PERMISSION_CONFIG_REQ = 1;
@@ -98,15 +101,17 @@ public class MainActivity extends MercuryActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        Server server = adapter.getServer(pager.getCurrentItem());
         switch (item.getItemId()) {
             case R.id.action_reload:
                 loadConfigFiles();
                 return true;
             case R.id.action_export_public_key:
-                exportPublicKey();
+                exportPublicKey(ServerAuthType.valueOf(ServerAuthType.appendDefaultLength(server
+                        .getAuthType())));
                 return true;
             case R.id.action_send_public_key:
-                new SshCommandPubKey().start();
+                new SshCommandPubKey(new SshServer(server, this)).start();
                 return true;
             case R.id.action_log:
                 startActivity(new Intent(this, LogActivity.class));
@@ -127,7 +132,9 @@ public class MainActivity extends MercuryActivity {
                     loadConfigFiles();
                     break;
                 case STORAGE_PERMISSION_PUB_REQ:
-                    exportPublicKey();
+                    Server server = adapter.getServer(pager.getCurrentItem());
+                    exportPublicKey(ServerAuthType.valueOf(ServerAuthType.appendDefaultLength
+                            (server.getAuthType())));
                     break;
             }
         }
@@ -181,7 +188,7 @@ public class MainActivity extends MercuryActivity {
         }
     }
 
-    private void exportPublicKey() {
+    private void exportPublicKey(final ServerAuthType authType) {
         if (!busy) {
             new AsyncTask<Void, Void, ExportPublicKeyStatus>() {
                 @Override
@@ -191,7 +198,7 @@ public class MainActivity extends MercuryActivity {
 
                 @Override
                 protected ExportPublicKeyStatus doInBackground(Void... params) {
-                    return SshManager.getInstance().exportPublicKey();
+                    return SshManager.getInstance().exportPublicKey(authType);
                 }
 
                 @Override
@@ -203,7 +210,7 @@ public class MainActivity extends MercuryActivity {
                         toast = !requestStoragePermission(STORAGE_PERMISSION_PUB_REQ);
                     }
                     if (toast) {
-                        Toast.makeText(MainActivity.this, getString(status.message(), SshManager.getInstance().getPublicKeyExportedFile()), Toast.LENGTH_LONG).show();
+                        Toast.makeText(MainActivity.this, getString(status.message(), SshManager.getInstance().getPublicKeyExportedFile(authType)), Toast.LENGTH_LONG).show();
                     }
                 }
             }.execute();

--- a/app/src/main/java/it/skarafaz/mercury/activity/MainActivity.java
+++ b/app/src/main/java/it/skarafaz/mercury/activity/MainActivity.java
@@ -26,6 +26,7 @@ import org.greenrobot.eventbus.EventBus;
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import it.skarafaz.mercury.R;
+import it.skarafaz.mercury.adapter.CommandListAdapter;
 import it.skarafaz.mercury.adapter.ServerPagerAdapter;
 import it.skarafaz.mercury.fragment.ProgressDialogFragment;
 import it.skarafaz.mercury.manager.ConfigManager;
@@ -249,5 +250,9 @@ public class MainActivity extends MercuryActivity {
             ft.remove(frag);
         }
         ft.commitAllowingStateLoss();
+    }
+
+    protected void onCommandListChanged() {
+        ((CommandListAdapter) adapter.getCurrentFragment().getListAdapter()).notifyDataSetInvalidated();
     }
 }

--- a/app/src/main/java/it/skarafaz/mercury/activity/MainEventSubscriber.java
+++ b/app/src/main/java/it/skarafaz/mercury/activity/MainEventSubscriber.java
@@ -1,7 +1,16 @@
 package it.skarafaz.mercury.activity;
 
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
 import android.text.InputType;
+import android.text.format.Formatter;
+import android.webkit.MimeTypeMap;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
@@ -11,8 +20,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
 
 import it.skarafaz.mercury.R;
+import it.skarafaz.mercury.event.SftpDownloadEnd;
+import it.skarafaz.mercury.event.SftpDownloadProgress;
+import it.skarafaz.mercury.event.SftpDownloadStart;
 import it.skarafaz.mercury.event.SshCommandConfirm;
 import it.skarafaz.mercury.event.SshCommandEnd;
 import it.skarafaz.mercury.event.SshCommandMessage;
@@ -23,10 +39,117 @@ import it.skarafaz.mercury.event.SshCommandYesNo;
 import it.skarafaz.mercury.ssh.SshCommandStatus;
 
 public class MainEventSubscriber {
+    private static final Logger logger = LoggerFactory.getLogger(MainEventSubscriber.class);
     private MainActivity activity;
+    private NotificationManager notificationManager;
+    private MimeTypeMap mimeTypeMap;
+    private HashMap<Integer, NotificationCompat.Builder> notificationBuilders;
 
     public MainEventSubscriber(MainActivity activity) {
         this.activity = activity;
+        notificationManager = (NotificationManager) activity.getSystemService(Context.NOTIFICATION_SERVICE);
+        mimeTypeMap = MimeTypeMap.getSingleton();
+        notificationBuilders = new HashMap<Integer, NotificationCompat.Builder>();
+    }
+
+    private String fileExt(String url) {
+        if (url.indexOf("?") > -1) {
+            url = url.substring(0, url.indexOf("?"));
+        }
+        if (url.lastIndexOf(".") == -1) {
+            return null;
+        } else {
+            String ext = url.substring(url.lastIndexOf(".") + 1);
+            if (ext.indexOf("%") > -1) {
+                ext = ext.substring(0, ext.indexOf("%"));
+            }
+            if (ext.indexOf("/") > -1) {
+                ext = ext.substring(0, ext.indexOf("/"));
+            }
+            return ext.toLowerCase();
+        }
+    }
+
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    public void onSftpDownloadEnd(final SftpDownloadEnd event) {
+        NotificationCompat.Builder notificationBuilder = notificationBuilders.get(event.getId());
+        Intent viewIntent = null;
+        if (event.getStatus() == SshCommandStatus.COMMAND_SUCCESSFUL) {
+            notificationBuilder
+                    .setOngoing(true)
+                    .setTicker(activity.getString(R.string.download_succeeded))
+                    .setContentTitle(activity.getString(R.string.download_succeeded))
+                    .setContentText(String.format(activity.getString(R.string.download_succeeded_file),
+                        event.getFile().getName()));
+            // Include a pending intent in the notification viewing the file or start the intent directly
+            viewIntent = new Intent(Intent.ACTION_VIEW);
+            String mimeType = mimeTypeMap.getMimeTypeFromExtension(fileExt(event.getFile().toString()));
+            logger.debug(String.format("view %s (extension %s, mime type %s)", fileExt(event.getFile().toString()),
+                    event.getFile(), mimeType));
+            viewIntent.setDataAndType(Uri.fromFile(event.getFile()), mimeType);
+            viewIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            notificationBuilder.setContentIntent(PendingIntent.getActivity(activity, (int)
+                    System.currentTimeMillis(), viewIntent, 0));
+        } else {
+            notificationBuilder
+                    .setTicker(activity.getString(R.string.download_failed))
+                    .setContentTitle(activity.getString(R.string.download_failed))
+                    .setContentText(String.format(activity.getString(R.string.download_failed_file),
+                        event.getFile().getName()));
+        }
+        if (event.getStatus() == SshCommandStatus.COMMAND_SUCCESSFUL && event.getView()) {
+            try {
+                activity.startActivity(viewIntent);
+                notificationManager.cancel(event.getId());
+            } catch (ActivityNotFoundException e) {
+                logger.debug("Could not start view activity: ", e);
+                Toast.makeText(activity, R.string.no_handler, Toast.LENGTH_LONG).show();
+            }
+        } else {
+            notificationBuilder
+                    .setAutoCancel(true)
+                    .setOngoing(false)
+                    .setProgress(0, 0, false);
+            notificationManager.notify(event.getId(), notificationBuilder.build());
+        }
+        EventBus.getDefault().removeStickyEvent(event);
+    }
+
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    public void onSftpDownloadProgress(final SftpDownloadProgress event) {
+        long progress = event.getProgress();
+        long max = event.getMax();
+        while (max > (1L << 31)) {
+            max >>= 1;
+            progress >>= 1;
+        }
+        NotificationCompat.Builder notificationBuilder = notificationBuilders.get(event.getId());
+        notificationBuilder
+                .setProgress((int) max, (int) progress, false)
+                .setContentText(String.format(activity.getString(R.string.downloading_percent), 100 * progress /
+                        max, event.getFile().getName(), Formatter.formatFileSize(activity, progress), Formatter
+                        .formatFileSize(activity, max)));
+        notificationManager.notify(event.getId(), notificationBuilder.build());
+
+        EventBus.getDefault().removeStickyEvent(event);
+    }
+
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    public void onSftpDownloadStart(final SftpDownloadStart event) {
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(activity);
+        notificationBuilders.put(event.getId(), new NotificationCompat.Builder(activity));
+        notificationBuilder = notificationBuilders.get(event.getId());
+        notificationBuilder
+                .setSmallIcon(R.drawable.ic_launcher)
+                .setTicker(activity.getString(R.string.downloading))
+                .setContentTitle(activity.getString(R.string.downloading))
+                .setOngoing(true)
+                .setProgress(0, 0, true)
+                .setContentText(String.format(activity.getString(R.string.downloading_starting), event.getFile()
+                        .getName()));
+        notificationManager.notify(event.getId(), notificationBuilder.build());
+
+        EventBus.getDefault().removeStickyEvent(event);
     }
 
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/it/skarafaz/mercury/activity/MainEventSubscriber.java
+++ b/app/src/main/java/it/skarafaz/mercury/activity/MainEventSubscriber.java
@@ -34,6 +34,7 @@ import it.skarafaz.mercury.event.SshCommandEnd;
 import it.skarafaz.mercury.event.SshCommandMessage;
 import it.skarafaz.mercury.event.SshCommandPassword;
 import it.skarafaz.mercury.event.SshCommandPubKeyInput;
+import it.skarafaz.mercury.event.SshCommandRulerUpdate;
 import it.skarafaz.mercury.event.SshCommandStart;
 import it.skarafaz.mercury.event.SshCommandYesNo;
 import it.skarafaz.mercury.ssh.SshCommandStatus;
@@ -308,6 +309,13 @@ public class MainEventSubscriber {
                     }
                 })
                 .show();
+
+        EventBus.getDefault().removeStickyEvent(event);
+    }
+
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    public void onSshCommandRulerUpdate(SshCommandRulerUpdate event) {
+        activity.onCommandListChanged();
 
         EventBus.getDefault().removeStickyEvent(event);
     }

--- a/app/src/main/java/it/skarafaz/mercury/activity/MainEventSubscriber.java
+++ b/app/src/main/java/it/skarafaz/mercury/activity/MainEventSubscriber.java
@@ -20,6 +20,7 @@ import it.skarafaz.mercury.event.SshCommandPassword;
 import it.skarafaz.mercury.event.SshCommandPubKeyInput;
 import it.skarafaz.mercury.event.SshCommandStart;
 import it.skarafaz.mercury.event.SshCommandYesNo;
+import it.skarafaz.mercury.ssh.SshCommandStatus;
 
 public class MainEventSubscriber {
     private MainActivity activity;
@@ -56,15 +57,27 @@ public class MainEventSubscriber {
 
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onSshCommandStart(SshCommandStart event) {
-        activity.showProgressDialog(activity.getString(R.string.sending_command));
+        if (event.getBackground()) {
+            activity.onCommandListChanged();
+        } else {
+            activity.showProgressDialog(activity.getString(R.string.sending_command));
+        }
 
         EventBus.getDefault().removeStickyEvent(event);
     }
 
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onSshCommandEnd(SshCommandEnd event) {
-        Toast.makeText(activity, activity.getString(event.getStatus().message()), Toast.LENGTH_SHORT).show();
-        activity.dismissProgressDialog();
+        if (!event.getSilent() || (event.getStatus() != SshCommandStatus.COMMAND_SUCCESSFUL &&
+                event.getStatus() != SshCommandStatus.COMMAND_SENT)) {
+            Toast.makeText(activity, activity.getString(event.getStatus().message()), Toast
+                    .LENGTH_SHORT).show();
+        }
+        if (event.getBackground()) {
+            activity.onCommandListChanged();
+        } else {
+            activity.dismissProgressDialog();
+        }
 
         EventBus.getDefault().removeStickyEvent(event);
     }

--- a/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
+++ b/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
@@ -3,34 +3,40 @@ package it.skarafaz.mercury.adapter;
 import android.content.Context;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
-import android.util.Log;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
+import android.widget.SeekBar;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.jcraft.jsch.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import it.skarafaz.mercury.R;
-import it.skarafaz.mercury.model.Command;
+import it.skarafaz.mercury.model.Entry;
+import it.skarafaz.mercury.model.RegularCommand;
+import it.skarafaz.mercury.model.Ruler;
 import it.skarafaz.mercury.ssh.SshCommandRegular;
+import it.skarafaz.mercury.ssh.SshCommandRulerGet;
+import it.skarafaz.mercury.ssh.SshCommandRulerSet;
 import it.skarafaz.mercury.ssh.SshServer;
 import it.skarafaz.mercury.view.TextProgressBar;
 
-public class CommandListAdapter extends ArrayAdapter<Command> {
+public class CommandListAdapter extends ArrayAdapter<Entry> {
+    private static final Logger logger = LoggerFactory.getLogger(CommandListAdapter.class);
     protected final SshServer server;
 
-    public CommandListAdapter(Context context, SshServer server, List<Command> commands) {
-        super(context, R.layout.command_list_item, commands);
+    public CommandListAdapter(Context context, SshServer server, List<Entry> entries) {
+        super(context, R.layout.command_list_item, entries);
         this.server = server;
     }
 
@@ -46,31 +52,67 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
             holder = (ViewHolder) view.getTag();
         }
 
-        final Command command = getItem(position);
-        if (command.getIcon() == null) {
+        final Entry entry = getItem(position);
+        if (entry.getIcon() == null) {
             holder.icon.setVisibility(View.INVISIBLE);
         } else {
             holder.icon.setVisibility(View.VISIBLE);
-            holder.icon.setImageBitmap(BitmapFactory.decodeFile(command.getIcon()));
+            holder.icon.setImageBitmap(BitmapFactory.decodeFile(entry.getIcon()));
         }
 
-        holder.name.setText(command.getName());
-        holder.progress.setText(command.getMultiple() ? String.valueOf(command.getRunning()) : "");
-        holder.progress.setVisibility(command.getRunning() == 0 ? View.INVISIBLE : View.VISIBLE);
+        holder.name.setText(entry.getName());
+        if (entry instanceof Ruler) {
+            final Ruler ruler = (Ruler) entry;
+            holder.name.setVisibility(View.INVISIBLE);
+            holder.ruler.setVisibility(View.VISIBLE);
+            holder.ruler.setMax((ruler.getMax() - ruler.getMin() + ruler.getStep() - 1) / ruler.getStep());
+            if (ruler.getValue() != null) {
+                holder.ruler.setProgress(ruler.getValue());
+            } else if (entry.getRunning() == 0) {
+                logger.trace(String.format("Ruler %s has no value, starting get command...", ruler.getName()));
+                new SshCommandRulerGet(server, ruler).start();
+            }
+            holder.ruler.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                    if (fromUser) {
+                        ruler.setValue(progress * ruler.getStep() + ruler.getMin());
+                        logger.trace(String.format("Ruler %s changed to, starting set command...", ruler.getName(),
+                                ruler.getValue()));
+                        (new SshCommandRulerSet(server, ruler)).start();
+                    }
+                }
+
+                @Override
+                public void onStartTrackingTouch(SeekBar seekBar) {}
+
+                @Override
+                public void onStopTrackingTouch(SeekBar seekBar) {}
+            });
+        } else {
+            holder.name.setVisibility(View.VISIBLE);
+            holder.ruler.setVisibility(View.INVISIBLE);
+        }
+        holder.progress.setText(entry.getProgressText());
+        holder.progress.setVisibility(entry.getRunning() == 0 ? View.INVISIBLE : View.VISIBLE);
         holder.info.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 new MaterialDialog.Builder(getContext())
-                        .title(command.getName())
-                        .content(command.getCmd())
+                        .title(entry.getName())
+                        .content(entry.getInfo())
                         .show();
             }
         });
         holder.row.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (command.getMultiple() || command.getRunning() == 0) {
-                    new SshCommandRegular(server, command).start();
+                if (entry instanceof RegularCommand) {
+                    if (entry.getRunning() == 0 || ((RegularCommand) entry).getMultiple()) {
+                        new SshCommandRegular(server, (RegularCommand) entry).start();
+                    }
+                } else if (entry instanceof Ruler && entry.getRunning() == 0) {
+                    new SshCommandRulerGet(server, (Ruler) entry).start();
                 }
             }
         });
@@ -84,6 +126,8 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
         ImageView icon;
         @Bind(R.id.name)
         TextView name;
+        @Bind(R.id.ruler)
+        SeekBar ruler;
         @Bind(R.id.progress)
         TextProgressBar progress;
         @Bind(R.id.info)

--- a/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
+++ b/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
@@ -2,6 +2,9 @@ package it.skarafaz.mercury.adapter;
 
 import android.content.Context;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.util.Log;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +14,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.jcraft.jsch.Logger;
 
 import java.util.List;
 
@@ -20,6 +24,7 @@ import it.skarafaz.mercury.R;
 import it.skarafaz.mercury.model.Command;
 import it.skarafaz.mercury.ssh.SshCommandRegular;
 import it.skarafaz.mercury.ssh.SshServer;
+import it.skarafaz.mercury.view.TextProgressBar;
 
 public class CommandListAdapter extends ArrayAdapter<Command> {
     protected final SshServer server;
@@ -50,6 +55,8 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
         }
 
         holder.name.setText(command.getName());
+        holder.progress.setText(command.getMultiple() ? String.valueOf(command.getRunning()) : "");
+        holder.progress.setVisibility(command.getRunning() == 0 ? View.INVISIBLE : View.VISIBLE);
         holder.info.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -62,7 +69,9 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
         holder.row.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                new SshCommandRegular(server, command).start();
+                if (command.getMultiple() || command.getRunning() == 0) {
+                    new SshCommandRegular(server, command).start();
+                }
             }
         });
         return view;
@@ -75,11 +84,15 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
         ImageView icon;
         @Bind(R.id.name)
         TextView name;
+        @Bind(R.id.progress)
+        TextProgressBar progress;
         @Bind(R.id.info)
         ImageView info;
 
         public ViewHolder(View view) {
             ButterKnife.bind(this, view);
+            progress.setTextColor(Color.WHITE);
+            progress.setTextSize(32);
         }
     }
 }

--- a/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
+++ b/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
@@ -19,11 +19,14 @@ import butterknife.ButterKnife;
 import it.skarafaz.mercury.R;
 import it.skarafaz.mercury.model.Command;
 import it.skarafaz.mercury.ssh.SshCommandRegular;
+import it.skarafaz.mercury.ssh.SshServer;
 
 public class CommandListAdapter extends ArrayAdapter<Command> {
+    protected final SshServer server;
 
-    public CommandListAdapter(Context context, List<Command> commands) {
+    public CommandListAdapter(Context context, SshServer server, List<Command> commands) {
         super(context, R.layout.command_list_item, commands);
+        this.server = server;
     }
 
     @Override
@@ -59,7 +62,7 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
         holder.row.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                new SshCommandRegular(command).start();
+                new SshCommandRegular(server, command).start();
             }
         });
         return view;

--- a/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
+++ b/app/src/main/java/it/skarafaz/mercury/adapter/CommandListAdapter.java
@@ -1,6 +1,7 @@
 package it.skarafaz.mercury.adapter;
 
 import android.content.Context;
+import android.graphics.BitmapFactory;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,6 +39,13 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
         }
 
         final Command command = getItem(position);
+        if (command.getIcon() == null) {
+            holder.icon.setVisibility(View.INVISIBLE);
+        } else {
+            holder.icon.setVisibility(View.VISIBLE);
+            holder.icon.setImageBitmap(BitmapFactory.decodeFile(command.getIcon()));
+        }
+
         holder.name.setText(command.getName());
         holder.info.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -60,6 +68,8 @@ public class CommandListAdapter extends ArrayAdapter<Command> {
     static class ViewHolder {
         @Bind(R.id.row)
         RelativeLayout row;
+        @Bind(R.id.icon)
+        ImageView icon;
         @Bind(R.id.name)
         TextView name;
         @Bind(R.id.info)

--- a/app/src/main/java/it/skarafaz/mercury/adapter/ServerPagerAdapter.java
+++ b/app/src/main/java/it/skarafaz/mercury/adapter/ServerPagerAdapter.java
@@ -3,6 +3,7 @@ package it.skarafaz.mercury.adapter;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
+import android.view.ViewGroup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +13,7 @@ import it.skarafaz.mercury.model.Server;
 
 public class ServerPagerAdapter extends FragmentStatePagerAdapter {
     private List<Server> servers;
+    private ServerFragment currentFragment;
 
     public ServerPagerAdapter(FragmentManager fm) {
         super(fm);
@@ -31,6 +33,16 @@ public class ServerPagerAdapter extends FragmentStatePagerAdapter {
 
     public Server getServer(int i) {
         return servers.get(i);
+    }
+
+    public ServerFragment getCurrentFragment() {
+        return currentFragment;
+    }
+
+    @Override
+    public void setPrimaryItem(ViewGroup container, int position, Object object) {
+        super.setPrimaryItem(container, position, object);
+        currentFragment = (ServerFragment) object;
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/adapter/ServerPagerAdapter.java
+++ b/app/src/main/java/it/skarafaz/mercury/adapter/ServerPagerAdapter.java
@@ -29,6 +29,10 @@ public class ServerPagerAdapter extends FragmentStatePagerAdapter {
         return ServerFragment.newInstance(servers.get(i));
     }
 
+    public Server getServer(int i) {
+        return servers.get(i);
+    }
+
     @Override
     public CharSequence getPageTitle(int position) {
         return servers.get(position).getName();

--- a/app/src/main/java/it/skarafaz/mercury/adapter/ServerPagerAdapter.java
+++ b/app/src/main/java/it/skarafaz/mercury/adapter/ServerPagerAdapter.java
@@ -28,10 +28,12 @@ public class ServerPagerAdapter extends FragmentStatePagerAdapter {
 
     @Override
     public Fragment getItem(int i) {
+        if (i >= servers.size()) return null;
         return ServerFragment.newInstance(servers.get(i));
     }
 
     public Server getServer(int i) {
+        if (i >= servers.size()) return null;
         return servers.get(i);
     }
 

--- a/app/src/main/java/it/skarafaz/mercury/event/SftpDownloadEnd.java
+++ b/app/src/main/java/it/skarafaz/mercury/event/SftpDownloadEnd.java
@@ -1,0 +1,36 @@
+package it.skarafaz.mercury.event;
+
+import java.io.File;
+
+import it.skarafaz.mercury.ssh.SshCommandStatus;
+
+
+public class SftpDownloadEnd {
+    private int id;
+    private File file;
+    private SshCommandStatus status;
+    private Boolean view;
+
+    public SftpDownloadEnd(int id, File file, SshCommandStatus status, Boolean view) {
+        this.id = id;
+        this.file = file;
+        this.status = status;
+        this.view = view;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public SshCommandStatus getStatus() {
+        return status;
+    }
+
+    public Boolean getView() {
+        return view;
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/event/SftpDownloadProgress.java
+++ b/app/src/main/java/it/skarafaz/mercury/event/SftpDownloadProgress.java
@@ -1,0 +1,33 @@
+package it.skarafaz.mercury.event;
+
+import java.io.File;
+
+public class SftpDownloadProgress {
+    private int id;
+    private File file;
+    private long progress;
+    private long max;
+
+    public SftpDownloadProgress(int id, File file, long progress, long max) {
+        this.id = id;
+        this.file = file;
+        this.progress = progress;
+        this.max = max;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public long getProgress() {
+        return progress;
+    }
+
+    public long getMax() {
+        return max;
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/event/SftpDownloadStart.java
+++ b/app/src/main/java/it/skarafaz/mercury/event/SftpDownloadStart.java
@@ -1,0 +1,21 @@
+package it.skarafaz.mercury.event;
+
+import java.io.File;
+
+public class SftpDownloadStart {
+    private int id;
+    private File file;
+
+    public SftpDownloadStart(int id, File file) {
+        this.id = id;
+        this.file = file;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public File getFile() {
+        return file;
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/event/SshCommandEnd.java
+++ b/app/src/main/java/it/skarafaz/mercury/event/SshCommandEnd.java
@@ -3,10 +3,22 @@ package it.skarafaz.mercury.event;
 import it.skarafaz.mercury.ssh.SshCommandStatus;
 
 public class SshCommandEnd {
+    private Boolean background;
+    private Boolean silent;
     private SshCommandStatus status;
 
-    public SshCommandEnd(SshCommandStatus status) {
+    public SshCommandEnd(Boolean background, Boolean silent, SshCommandStatus status) {
+        this.background = background;
+        this.silent = silent;
         this.status = status;
+    }
+
+    public Boolean getBackground() {
+        return background;
+    }
+
+    public Boolean getSilent() {
+        return silent;
     }
 
     public SshCommandStatus getStatus() {

--- a/app/src/main/java/it/skarafaz/mercury/event/SshCommandRulerUpdate.java
+++ b/app/src/main/java/it/skarafaz/mercury/event/SshCommandRulerUpdate.java
@@ -1,0 +1,4 @@
+package it.skarafaz.mercury.event;
+
+public class SshCommandRulerUpdate {
+}

--- a/app/src/main/java/it/skarafaz/mercury/event/SshCommandStart.java
+++ b/app/src/main/java/it/skarafaz/mercury/event/SshCommandStart.java
@@ -1,4 +1,13 @@
 package it.skarafaz.mercury.event;
 
 public class SshCommandStart {
+    private Boolean background;
+
+    public SshCommandStart(Boolean background) {
+        this.background = background;
+    }
+
+    public Boolean getBackground() {
+        return background;
+    }
 }

--- a/app/src/main/java/it/skarafaz/mercury/fragment/ServerFragment.java
+++ b/app/src/main/java/it/skarafaz/mercury/fragment/ServerFragment.java
@@ -41,7 +41,7 @@ public class ServerFragment extends ListFragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        setListAdapter(new CommandListAdapter(getActivity(), sshServer, server.getCommands()));
+        setListAdapter(new CommandListAdapter(getActivity(), sshServer, server.getEntries()));
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/fragment/ServerFragment.java
+++ b/app/src/main/java/it/skarafaz/mercury/fragment/ServerFragment.java
@@ -9,10 +9,12 @@ import android.view.ViewGroup;
 import it.skarafaz.mercury.R;
 import it.skarafaz.mercury.adapter.CommandListAdapter;
 import it.skarafaz.mercury.model.Server;
+import it.skarafaz.mercury.ssh.SshServer;
 
 public class ServerFragment extends ListFragment {
     public static final String SERVER_ARG = "SERVER_ARG";
     private Server server;
+    private SshServer sshServer;
 
     public static ServerFragment newInstance(Server server) {
         ServerFragment fragment = new ServerFragment();
@@ -27,6 +29,7 @@ public class ServerFragment extends ListFragment {
         super.onCreate(savedInstanceState);
 
         server = getArguments() != null ? (Server) getArguments().getSerializable(SERVER_ARG) : null;
+        sshServer = new SshServer(server);
     }
 
     @Override
@@ -38,6 +41,13 @@ public class ServerFragment extends ListFragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        setListAdapter(new CommandListAdapter(getActivity(), server.getCommands()));
+        setListAdapter(new CommandListAdapter(getActivity(), sshServer, server.getCommands()));
     }
+
+    @Override
+    public void onPause() {
+        sshServer.disconnect();
+        super.onPause();
+     }
+
 }

--- a/app/src/main/java/it/skarafaz/mercury/fragment/ServerFragment.java
+++ b/app/src/main/java/it/skarafaz/mercury/fragment/ServerFragment.java
@@ -29,7 +29,7 @@ public class ServerFragment extends ListFragment {
         super.onCreate(savedInstanceState);
 
         server = getArguments() != null ? (Server) getArguments().getSerializable(SERVER_ARG) : null;
-        sshServer = new SshServer(server);
+        sshServer = new SshServer(server, getContext());
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
+++ b/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import it.skarafaz.mercury.MercuryApplication;
 import it.skarafaz.mercury.R;
+import it.skarafaz.mercury.manager.ConfigManager;
 import it.skarafaz.mercury.model.Command;
 import it.skarafaz.mercury.model.Server;
 
@@ -68,6 +69,10 @@ public class ServerMapper {
 
     private Map<String, String> validateCommand(Command command, int index) {
         Map<String, String> errors = new LinkedHashMap<>();
+        if (command.getIcon() != null) {
+            command.setIcon(new File(ConfigManager.getInstance().getConfigDir(), command.getIcon())
+                    .getAbsolutePath());
+        }
         if (StringUtils.isBlank(command.getName())) {
             command.setName(getString(R.string.command));
         }

--- a/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
+++ b/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
@@ -1,12 +1,28 @@
 package it.skarafaz.mercury.jackson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -14,14 +30,20 @@ import it.skarafaz.mercury.MercuryApplication;
 import it.skarafaz.mercury.R;
 import it.skarafaz.mercury.manager.ConfigManager;
 import it.skarafaz.mercury.model.Command;
+import it.skarafaz.mercury.model.Entry;
+import it.skarafaz.mercury.model.RegularCommand;
+import it.skarafaz.mercury.model.Ruler;
 import it.skarafaz.mercury.model.Server;
 import it.skarafaz.mercury.model.ServerAuthType;
 
 public class ServerMapper {
+    private static final Logger logger = LoggerFactory.getLogger(ServerMapper.class);
     private ObjectMapper mapper;
 
     public ServerMapper() {
+        PolymorphicDeserializer deserializer = new PolymorphicDeserializer(Entry.class, RegularCommand.class, Ruler.class);
         mapper = new ObjectMapper();
+        mapper.registerModule((new SimpleModule()).addDeserializer(Entry.class, deserializer));
     }
 
     public Server readValue(File src) throws IOException, ValidationException {
@@ -69,30 +91,36 @@ public class ServerMapper {
         if (StringUtils.isBlank(server.getNohupPath())) {
             server.setNohupPath("nohup");
         }
-        if (server.getCommands() == null) {
-            server.setCommands(new ArrayList<Command>());
+        if (server.getEntries() == null) {
+            server.setEntries(new ArrayList<Entry>());
         } else {
-            for (int i = 0; i < server.getCommands().size(); i++) {
-                errors.putAll(validateCommand(server.getCommands().get(i), i));
+            for (int i = 0; i < server.getEntries().size(); i++) {
+                errors.putAll(validateEntry(server, server.getEntries().get(i), i));
             }
+        }
+        return errors;
+    }
+
+    private Map<String, String> validateEntry(Server server, Entry entry, int index) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        entry.setServer(server);
+        if (entry.getIcon() != null) {
+            entry.setIcon(new File(ConfigManager.getInstance().getConfigDir(), entry.getIcon())
+                    .getAbsolutePath());
+        }
+        if (StringUtils.isBlank(entry.getName())) {
+            entry.setName(getString(R.string.command));
+        }
+        if (entry instanceof Command) {
+            errors.putAll(validateCommand((Command) entry, index));
         }
         return errors;
     }
 
     private Map<String, String> validateCommand(Command command, int index) {
         Map<String, String> errors = new LinkedHashMap<>();
-        if (command.getIcon() != null) {
-            command.setIcon(new File(ConfigManager.getInstance().getConfigDir(), command.getIcon())
-                    .getAbsolutePath());
-        }
-        if (StringUtils.isBlank(command.getName())) {
-            command.setName(getString(R.string.command));
-        }
         if (command.getSudo() == null) {
             command.setSudo(Boolean.FALSE);
-        }
-        if (StringUtils.isBlank(command.getCmd())) {
-            errors.put(String.format("commands[%d].cmd", index), getString(R.string.validation_missing));
         }
         if (command.getConfirm() == null) {
             command.setConfirm(Boolean.FALSE);
@@ -103,11 +131,44 @@ public class ServerMapper {
         if (command.getBackground() == null) {
             command.setBackground(Boolean.FALSE);
         }
-        if (command.getMultiple() == null) {
-            command.setMultiple(Boolean.FALSE);
-        }
         if (command.getSilent() == null) {
             command.setSilent(Boolean.FALSE);
+        }
+        if (command instanceof RegularCommand) {
+            errors.putAll(validateRegularCommand((RegularCommand) command, index));
+        } else if (command instanceof Ruler) {
+            errors.putAll(validateRuler((Ruler) command, index));
+        }
+        return errors;
+    }
+
+    private Map<String, String> validateRuler(Ruler ruler, int index) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        if (StringUtils.isBlank(ruler.getGetCmd())) {
+            errors.put(String.format("commands[%d].getcmd", index), getString(R.string.validation_missing));
+        }
+        if (StringUtils.isBlank(ruler.getSetCmd())) {
+            errors.put(String.format("commands[%d].setcmd", index), getString(R.string.validation_missing));
+        }
+        if (ruler.getMin() == null) {
+            ruler.setMin(0);
+        }
+        if (ruler.getMax() == null) {
+            ruler.setMax(100);
+        }
+        if (ruler.getStep() == null) {
+            ruler.setStep(1);
+        }
+        return errors;
+    }
+
+    private Map<String, String> validateRegularCommand(RegularCommand command, int index) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        if (StringUtils.isBlank(command.getCmd())) {
+            errors.put(String.format("commands[%d].cmd", index), getString(R.string.validation_missing));
+        }
+        if (command.getMultiple() == null) {
+            command.setMultiple(Boolean.FALSE);
         }
         if (command.getView() == null) {
             command.setView(Boolean.FALSE);
@@ -134,5 +195,55 @@ public class ServerMapper {
 
     private String getString(int resId, Object... formatArgs) {
         return MercuryApplication.getContext().getString(resId, formatArgs);
+    }
+
+    private class PolymorphicDeserializer<T> extends StdDeserializer<T> {
+        private Map<Class<? extends T>, Collection<String>> registry;
+
+        public PolymorphicDeserializer(Class<T> baseClass, Class<? extends T>... args) {
+            super((Class<T>) baseClass.getClass());
+            registry = new HashMap<>();
+            for (Class<? extends T> arg : args) {
+                Collection<String> fields = new HashSet<>();
+                for (Class cls = arg; cls != null; cls = cls.getSuperclass()) {
+                    for (Field field : cls.getDeclaredFields()) {
+                        String name = field.getName();
+                        for (Annotation annotation : field.getDeclaredAnnotations()) {
+                            if (annotation instanceof JsonProperty) {
+                                name = ((JsonProperty) annotation).value();
+                                break;
+                            }
+                        }
+                        fields.add(name);
+                    }
+                }
+                logger.debug(String.format("Registering %s as extension of %s with fields %s", arg.getName(), baseClass
+                        .getName(), Arrays.toString(fields.toArray())));
+                registry.put(arg, fields);
+            }
+        }
+
+        @Override
+        public T deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+            ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+            ObjectNode root = (ObjectNode) mapper.readTree(jp);
+            for (Map.Entry<Class<? extends T>, Collection<String>> entry: registry.entrySet()) {
+                boolean valid = true;
+                for (Iterator<Map.Entry<String, JsonNode>> it = root.fields(); it.hasNext(); ) {
+                    Map.Entry<String, JsonNode> element = it.next();
+                    if (!entry.getValue().contains(element.getKey())) {
+                        logger.trace(String.format("deserialize for %s: class %s misses property %s", root, entry
+                                .getKey().getName(), element.getKey()));
+                        valid = false;
+                        break;
+                    }
+                }
+                if (valid) {
+                    logger.debug(String.format("deserialize for %s: use class %s", root, entry.getKey().getName()));
+                    return mapper.treeToValue(root, (Class<T>)entry.getKey());
+                }
+            }
+            return null;
+        }
     }
 }

--- a/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
+++ b/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
@@ -37,13 +37,16 @@ public class ServerMapper {
         if (StringUtils.isBlank(server.getName())) {
             server.setName(getString(R.string.server));
         }
-        if (StringUtils.isBlank(server.getHost())) {
-            errors.put("host", getString(R.string.validation_missing));
+        if (StringUtils.isBlank(server.getHost()) && StringUtils.isBlank(server.getMDnsName())) {
+            errors.put("host/mdnsname", getString(R.string.validation_missing));
         }
         if (server.getPort() == null) {
             server.setPort(22);
         } else if (server.getPort() < 1 || server.getPort() > 65535) {
             errors.put("port", getString(R.string.validation_invalid));
+        }
+        if (server.getMDnsType() == null) {
+            server.setMDnsType("_ssh._tcp");
         }
         if (StringUtils.isBlank(server.getUser())) {
             errors.put("user", getString(R.string.validation_missing));

--- a/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
+++ b/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
@@ -15,6 +15,7 @@ import it.skarafaz.mercury.R;
 import it.skarafaz.mercury.manager.ConfigManager;
 import it.skarafaz.mercury.model.Command;
 import it.skarafaz.mercury.model.Server;
+import it.skarafaz.mercury.model.ServerAuthType;
 
 public class ServerMapper {
     private ObjectMapper mapper;
@@ -53,6 +54,14 @@ public class ServerMapper {
         }
         if (StringUtils.isEmpty(server.getPassword())) {
             server.setPassword(null);
+        }
+        if (StringUtils.isEmpty(server.getAuthType())) {
+            server.setAuthType(ServerAuthType.RSA2048.toString());
+        }
+        try {
+            ServerAuthType.valueOf(ServerAuthType.appendDefaultLength(server.getAuthType()));
+        } catch (IllegalArgumentException e) {
+            errors.put("authtype", getString(R.string.validation_invalid));
         }
         if (StringUtils.isBlank(server.getSudoPath())) {
             server.setSudoPath("sudo");

--- a/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
+++ b/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
@@ -109,6 +109,9 @@ public class ServerMapper {
         if (command.getSilent() == null) {
             command.setSilent(Boolean.FALSE);
         }
+        if (command.getView() == null) {
+            command.setView(Boolean.FALSE);
+        }
         return errors;
     }
 

--- a/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
+++ b/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
@@ -85,6 +85,9 @@ public class ServerMapper {
         if (command.getConfirm() == null) {
             command.setConfirm(Boolean.FALSE);
         }
+        if (command.getWait() == null) {
+            command.setWait(Boolean.FALSE);
+        }
         return errors;
     }
 

--- a/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
+++ b/app/src/main/java/it/skarafaz/mercury/jackson/ServerMapper.java
@@ -100,6 +100,15 @@ public class ServerMapper {
         if (command.getWait() == null) {
             command.setWait(Boolean.FALSE);
         }
+        if (command.getBackground() == null) {
+            command.setBackground(Boolean.FALSE);
+        }
+        if (command.getMultiple() == null) {
+            command.setMultiple(Boolean.FALSE);
+        }
+        if (command.getSilent() == null) {
+            command.setSilent(Boolean.FALSE);
+        }
         return errors;
     }
 

--- a/app/src/main/java/it/skarafaz/mercury/manager/SshManager.java
+++ b/app/src/main/java/it/skarafaz/mercury/manager/SshManager.java
@@ -30,6 +30,7 @@ public class SshManager {
 
     private SshManager() {
         this.jsch = new JSch();
+        migrateSshKeys();
     }
 
     public static synchronized SshManager getInstance() {
@@ -37,6 +38,32 @@ public class SshManager {
             instance = new SshManager();
         }
         return instance;
+    }
+
+    private void migrateSshKeys() {
+        /* Migrate old keys to new naming scheme */
+        File oldPrivateKeyFile = new File(getSshDir(), "id_rsa");
+        if (oldPrivateKeyFile.exists()) {
+            try {
+                FileUtils.moveFile(oldPrivateKeyFile, getPrivateKeyFile(ServerAuthType.RSA2048));
+                logger.info(String.format("Migrated old key %s to %s", oldPrivateKeyFile,
+                        getPrivateKeyFile(ServerAuthType.RSA2048)));
+            } catch (IOException e) {
+                logger.error(String.format("Could not migrate old key %s to %s: %s",
+                        oldPrivateKeyFile, getPrivateKeyFile(ServerAuthType.RSA2048), e));
+            }
+        }
+        File oldPublicKeyFile = new File(getSshDir(), "id_rsa.pub");
+        if (oldPublicKeyFile.exists()) {
+            try {
+                FileUtils.moveFile(oldPublicKeyFile, getPublicKeyFile(ServerAuthType.RSA2048));
+                logger.info(String.format("Migrated old key %s to %s", oldPrivateKeyFile,
+                        getPublicKeyFile(ServerAuthType.RSA2048)));
+            } catch (IOException e) {
+                logger.error(String.format("Could not migrate old key %s to %s: %s",
+                        oldPrivateKeyFile, getPublicKeyFile(ServerAuthType.RSA2048), e));
+            }
+        }
     }
 
     public File getKnownHosts() throws IOException {

--- a/app/src/main/java/it/skarafaz/mercury/manager/SshManager.java
+++ b/app/src/main/java/it/skarafaz/mercury/manager/SshManager.java
@@ -15,14 +15,14 @@ import java.io.File;
 import java.io.IOException;
 
 import it.skarafaz.mercury.MercuryApplication;
+import it.skarafaz.mercury.model.ServerAuthType;
 import it.skarafaz.mercury.ssh.SshCommandRegular;
 
 public class SshManager {
     private static final String SSH_DIR = "ssh";
     private static final String KNOWN_HOSTS_FILE = "known_hosts";
-    private static final int PRIVATE_KEY_LENGTH = 2048;
-    private static final String PRIVATE_KEY_FILE = "id_rsa";
-    private static final String PUBLIC_KEY_FILE = "id_rsa.pub";
+    private static final String PRIVATE_KEY_FILE = "id_%s";
+    private static final String PUBLIC_KEY_FILE = "id_%s.pub";
     private static final String PUBLIC_KEY_COMMENT = "mercuryssh";
     private static final Logger logger = LoggerFactory.getLogger(SshCommandRegular.class);
     private static SshManager instance;
@@ -45,36 +45,37 @@ public class SshManager {
         return file;
     }
 
-    public File getPrivateKey() throws IOException, JSchException {
-        File file = getPrivateKeyFile();
+    public File getPrivateKey(ServerAuthType authType) throws IOException, JSchException {
+        File file = getPrivateKeyFile(authType);
         if (!file.exists()) {
-            generatePrivateKey(file);
+            generatePrivateKey(authType, file);
         }
         return file;
     }
 
-    public File getPublicKey() throws IOException, JSchException {
-        File file = getPublicKeyFile();
+    public File getPublicKey(ServerAuthType authType) throws IOException, JSchException {
+        File file = getPublicKeyFile(authType);
         if (!file.exists()) {
-            generatePublicKey(file);
+            generatePublicKey(authType, file);
         }
         return file;
     }
 
-    public String getPublicKeyContent() throws IOException, JSchException {
-        return FileUtils.readFileToString(getPublicKey()).replace("\n", "");
+    public String getPublicKeyContent(ServerAuthType authType) throws IOException, JSchException {
+        return FileUtils.readFileToString(getPublicKey(authType)).replace("\n", "");
     }
 
-    public File getPublicKeyExportedFile() {
-        return new File(Environment.getExternalStorageDirectory(), PUBLIC_KEY_FILE);
+    public File getPublicKeyExportedFile(ServerAuthType authType) {
+        return new File(Environment.getExternalStorageDirectory(), String.format(PUBLIC_KEY_FILE,
+                authType.toString().toLowerCase()));
     }
 
-    public ExportPublicKeyStatus exportPublicKey() {
+    public ExportPublicKeyStatus exportPublicKey(ServerAuthType authType) {
         ExportPublicKeyStatus status = ExportPublicKeyStatus.SUCCESS;
         if (MercuryApplication.isExternalStorageWritable()) {
             if (MercuryApplication.storagePermissionGranted()) {
                 try {
-                    FileUtils.copyFile(getPublicKey(), getPublicKeyExportedFile());
+                    FileUtils.copyFile(getPublicKey(authType), getPublicKeyExportedFile(authType));
                 } catch (JSchException | IOException e) {
                     status = ExportPublicKeyStatus.ERROR;
                     logger.error(e.getMessage().replace("\n", " "));
@@ -92,26 +93,30 @@ public class SshManager {
         return new File(getSshDir(), KNOWN_HOSTS_FILE);
     }
 
-    private File getPrivateKeyFile() {
-        return new File(getSshDir(), PRIVATE_KEY_FILE);
+    private File getPrivateKeyFile(ServerAuthType authType) {
+        return new File(getSshDir(), String.format(PRIVATE_KEY_FILE, authType.toString()
+                .toLowerCase()));
     }
 
-    private File getPublicKeyFile() {
-        return new File(getSshDir(), PUBLIC_KEY_FILE);
+    private File getPublicKeyFile(ServerAuthType authType) {
+        return new File(getSshDir(), String.format(PUBLIC_KEY_FILE, authType.toString()
+                .toLowerCase()));
     }
 
     private File getSshDir() {
         return MercuryApplication.getContext().getDir(SSH_DIR, Context.MODE_PRIVATE);
     }
 
-    private void generatePrivateKey(File file) throws IOException, JSchException {
-        KeyPair kpair = KeyPair.genKeyPair(jsch, KeyPair.RSA, PRIVATE_KEY_LENGTH);
+    private void generatePrivateKey(ServerAuthType authType, File file) throws IOException,
+            JSchException {
+        KeyPair kpair = KeyPair.genKeyPair(jsch, authType.getKeyType(), authType.getKeySize());
         kpair.writePrivateKey(file.getAbsolutePath());
         kpair.dispose();
     }
 
-    private void generatePublicKey(File file) throws IOException, JSchException {
-        KeyPair kpair = KeyPair.load(jsch, getPrivateKey().getAbsolutePath());
+    private void generatePublicKey(ServerAuthType authType, File file) throws IOException,
+            JSchException {
+        KeyPair kpair = KeyPair.load(jsch, getPrivateKey(authType).getAbsolutePath());
         kpair.writePublicKey(file.getAbsolutePath(), PUBLIC_KEY_COMMENT);
         kpair.dispose();
     }

--- a/app/src/main/java/it/skarafaz/mercury/model/Command.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Command.java
@@ -14,6 +14,7 @@ public class Command implements Serializable, Comparable<Command> {
     private Boolean sudo;
     private String cmd;
     private Boolean confirm;
+    private Boolean wait;
     private Server server;
 
     public String getIcon() {
@@ -54,6 +55,14 @@ public class Command implements Serializable, Comparable<Command> {
 
     public void setConfirm(Boolean confirm) {
         this.confirm = confirm;
+    }
+
+    public Boolean getWait() {
+        return wait;
+    }
+
+    public void setWait(Boolean wait) {
+        this.wait = wait;
     }
 
     @JsonBackReference

--- a/app/src/main/java/it/skarafaz/mercury/model/Command.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Command.java
@@ -9,11 +9,20 @@ import java.io.Serializable;
 @SuppressWarnings("unused")
 public class Command implements Serializable, Comparable<Command> {
     private static final long serialVersionUID = -1107949489549383265L;
+    private String icon;
     private String name;
     private Boolean sudo;
     private String cmd;
     private Boolean confirm;
     private Server server;
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
 
     public String getName() {
         return name;

--- a/app/src/main/java/it/skarafaz/mercury/model/Command.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Command.java
@@ -3,6 +3,7 @@ package it.skarafaz.mercury.model;
 import android.support.annotation.NonNull;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.Serializable;
 
@@ -15,7 +16,13 @@ public class Command implements Serializable, Comparable<Command> {
     private String cmd;
     private Boolean confirm;
     private Boolean wait;
+    private Boolean background;
+    private Boolean multiple;
+    private Boolean silent;
     private Server server;
+
+    @JsonIgnore
+    private int running = 0;
 
     public String getIcon() {
         return icon;
@@ -63,6 +70,42 @@ public class Command implements Serializable, Comparable<Command> {
 
     public void setWait(Boolean wait) {
         this.wait = wait;
+    }
+
+    public Boolean getBackground() {
+        return background;
+    }
+
+    public void setBackground(Boolean background) {
+        this.background = background;
+    }
+
+    public Boolean getMultiple() {
+        return multiple;
+    }
+
+    public void setMultiple(Boolean multiple) {
+        this.multiple = multiple;
+    }
+
+    public Boolean getSilent() {
+        return silent;
+    }
+
+    public void setSilent(Boolean silent) {
+        this.silent = silent;
+    }
+
+    public int getRunning() {
+        return running;
+    }
+
+    public int increaseRunning() {
+        return ++this.running;
+    }
+
+    public int decreaseRunning() {
+        return --this.running;
     }
 
     @JsonBackReference

--- a/app/src/main/java/it/skarafaz/mercury/model/Command.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Command.java
@@ -1,46 +1,12 @@
 package it.skarafaz.mercury.model;
 
-import android.support.annotation.NonNull;
-
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import java.io.Serializable;
-
 @SuppressWarnings("unused")
-public class Command implements Serializable, Comparable<Command> {
-    private static final long serialVersionUID = -1107949489549383265L;
-    private String icon;
-    private String name;
+public abstract class Command extends Entry {
     private Boolean sudo;
-    private String cmd;
-    private String download;
     private Boolean confirm;
     private Boolean wait;
     private Boolean background;
-    private Boolean multiple;
     private Boolean silent;
-    private Boolean view;
-    private Server server;
-
-    @JsonIgnore
-    private int running = 0;
-
-    public String getIcon() {
-        return icon;
-    }
-
-    public void setIcon(String icon) {
-        this.icon = icon;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
 
     public Boolean getSudo() {
         return sudo;
@@ -48,22 +14,6 @@ public class Command implements Serializable, Comparable<Command> {
 
     public void setSudo(Boolean sudo) {
         this.sudo = sudo;
-    }
-
-    public String getCmd() {
-        return cmd;
-    }
-
-    public void setCmd(String cmd) {
-        this.cmd = cmd;
-    }
-
-    public String getDownload() {
-        return download;
-    }
-
-    public void setDownload(String download) {
-        this.download = download;
     }
 
     public Boolean getConfirm() {
@@ -90,52 +40,11 @@ public class Command implements Serializable, Comparable<Command> {
         this.background = background;
     }
 
-    public Boolean getMultiple() {
-        return multiple;
-    }
-
-    public void setMultiple(Boolean multiple) {
-        this.multiple = multiple;
-    }
-
     public Boolean getSilent() {
         return silent;
     }
 
     public void setSilent(Boolean silent) {
         this.silent = silent;
-    }
-
-    public Boolean getView() {
-        return view;
-    }
-
-    public void setView(Boolean view) {
-        this.view = view;
-    }
-    public int getRunning() {
-        return running;
-    }
-
-    public int increaseRunning() {
-        return ++this.running;
-    }
-
-    public int decreaseRunning() {
-        return --this.running;
-    }
-
-    @JsonBackReference
-    public Server getServer() {
-        return server;
-    }
-
-    public void setServer(Server server) {
-        this.server = server;
-    }
-
-    @Override
-    public int compareTo(@NonNull Command another) {
-        return name.toLowerCase().compareTo(another.getName().toLowerCase());
     }
 }

--- a/app/src/main/java/it/skarafaz/mercury/model/Command.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Command.java
@@ -14,11 +14,13 @@ public class Command implements Serializable, Comparable<Command> {
     private String name;
     private Boolean sudo;
     private String cmd;
+    private String download;
     private Boolean confirm;
     private Boolean wait;
     private Boolean background;
     private Boolean multiple;
     private Boolean silent;
+    private Boolean view;
     private Server server;
 
     @JsonIgnore
@@ -54,6 +56,14 @@ public class Command implements Serializable, Comparable<Command> {
 
     public void setCmd(String cmd) {
         this.cmd = cmd;
+    }
+
+    public String getDownload() {
+        return download;
+    }
+
+    public void setDownload(String download) {
+        this.download = download;
     }
 
     public Boolean getConfirm() {
@@ -96,6 +106,13 @@ public class Command implements Serializable, Comparable<Command> {
         this.silent = silent;
     }
 
+    public Boolean getView() {
+        return view;
+    }
+
+    public void setView(Boolean view) {
+        this.view = view;
+    }
     public int getRunning() {
         return running;
     }

--- a/app/src/main/java/it/skarafaz/mercury/model/Entry.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Entry.java
@@ -1,0 +1,64 @@
+package it.skarafaz.mercury.model;
+
+import android.support.annotation.NonNull;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.io.Serializable;
+
+@SuppressWarnings("unused")
+public abstract class Entry implements Serializable, Comparable<Entry> {
+    private static final long serialVersionUID = -1107949489549383265L;
+    private String icon;
+    private String name;
+
+    @JsonIgnore
+    private int running = 0;
+    @JsonIgnore
+    private Server server;
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getRunning() {
+        return running;
+    }
+
+    public int increaseRunning() {
+        return ++this.running;
+    }
+
+    public int decreaseRunning() {
+        return --this.running;
+    }
+
+    public Server getServer() {
+        return server;
+    }
+
+    public void setServer(Server server) {
+        this.server = server;
+    }
+
+    @Override
+    public int compareTo(@NonNull Entry another) {
+        return name.toLowerCase().compareTo(another.getName().toLowerCase());
+    }
+
+    public abstract String getInfo();
+    public abstract String getProgressText();
+}

--- a/app/src/main/java/it/skarafaz/mercury/model/RegularCommand.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/RegularCommand.java
@@ -1,0 +1,51 @@
+package it.skarafaz.mercury.model;
+
+@SuppressWarnings("unused")
+public class RegularCommand extends Command {
+    private String cmd;
+    private Boolean multiple;
+    private String download;
+    private Boolean view;
+
+    public String getCmd() {
+        return cmd;
+    }
+
+    public void setCmd(String cmd) {
+        this.cmd = cmd;
+    }
+
+    public Boolean getMultiple() {
+        return multiple;
+    }
+
+    public void setMultiple(Boolean multiple) {
+        this.multiple = multiple;
+    }
+
+    public String getDownload() {
+        return download;
+    }
+
+    public void setDownload(String download) {
+        this.download = download;
+    }
+
+    public Boolean getView() {
+        return view;
+    }
+
+    public void setView(Boolean view) {
+        this.view = view;
+    }
+
+    @Override
+    public String getInfo() {
+        return getCmd();
+    }
+
+    @Override
+    public String getProgressText() {
+        return getMultiple() ? String.valueOf(getRunning()) : "";
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/model/Ruler.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Ruler.java
@@ -1,0 +1,75 @@
+package it.skarafaz.mercury.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@SuppressWarnings("unused")
+public class Ruler extends Command {
+    @JsonProperty("getcmd")
+    private String getCmd;
+    @JsonProperty("setcmd")
+    private String setCmd;
+    private Integer min;
+    private Integer max;
+    private Integer step;
+
+    @JsonIgnore
+    private Integer value;
+
+    public String getGetCmd() {
+        return getCmd;
+    }
+
+    public void setGetCmd(String getCmd) {
+        this.getCmd = getCmd;
+    }
+
+    public String getSetCmd() {
+        return setCmd;
+    }
+
+    public void setSetCmd(String setCmd) {
+        this.setCmd = setCmd;
+    }
+
+    public Integer getMin() {
+        return min;
+    }
+
+    public void setMin(Integer min) {
+        this.min = min;
+    }
+
+    public Integer getMax() {
+        return max;
+    }
+
+    public void setMax(Integer max) {
+        this.max = max;
+    }
+
+    public Integer getStep() {
+        return step;
+    }
+
+    public void setStep(Integer step) {
+        this.step = step;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+
+    public String getInfo() {
+        return "GET: " + getGetCmd() + "\nSET: " + getSetCmd();
+    }
+
+    @Override
+    public String getProgressText() {
+        return "";
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/model/Server.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Server.java
@@ -20,6 +20,8 @@ public class Server implements Serializable, Comparable<Server> {
     private String mDnsType;
     private String user;
     private String password;
+    @JsonProperty("authtype")
+    private String authType;
     private String sudoPath;
     private String nohupPath;
     private List<Command> commands;
@@ -78,6 +80,14 @@ public class Server implements Serializable, Comparable<Server> {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getAuthType() {
+        return authType;
+    }
+
+    public void setAuthType(String authType) {
+        this.authType = authType;
     }
 
     public String getSudoPath() {

--- a/app/src/main/java/it/skarafaz/mercury/model/Server.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Server.java
@@ -24,7 +24,8 @@ public class Server implements Serializable, Comparable<Server> {
     private String authType;
     private String sudoPath;
     private String nohupPath;
-    private List<Command> commands;
+    @JsonProperty("commands")
+    private List<Entry> entries;
 
     public String getName() {
         return name;
@@ -106,13 +107,12 @@ public class Server implements Serializable, Comparable<Server> {
         this.nohupPath = nohupPath;
     }
 
-    @JsonManagedReference
-    public List<Command> getCommands() {
-        return commands;
+    public List<Entry> getEntries() {
+        return entries;
     }
 
-    public void setCommands(List<Command> commands) {
-        this.commands = commands;
+    public void setEntries(List<Entry> entries) {
+        this.entries = entries;
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/model/Server.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/Server.java
@@ -3,6 +3,7 @@ package it.skarafaz.mercury.model;
 import android.support.annotation.NonNull;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
 import java.util.List;
@@ -13,6 +14,10 @@ public class Server implements Serializable, Comparable<Server> {
     private String name;
     private String host;
     private Integer port;
+    @JsonProperty("mdnsname")
+    private String mDnsName;
+    @JsonProperty("mdnstype")
+    private String mDnsType;
     private String user;
     private String password;
     private String sudoPath;
@@ -41,6 +46,22 @@ public class Server implements Serializable, Comparable<Server> {
 
     public void setPort(Integer port) {
         this.port = port;
+    }
+
+    public String getMDnsName() {
+        return mDnsName;
+    }
+
+    public void setMDnsName(String mDnsName) {
+        this.mDnsName = mDnsName;
+    }
+
+    public String getMDnsType() {
+        return mDnsType;
+    }
+
+    public void setMDnsType(String mDnsType) {
+        this.mDnsType = mDnsType;
     }
 
     public String getUser() {

--- a/app/src/main/java/it/skarafaz/mercury/model/ServerAuthType.java
+++ b/app/src/main/java/it/skarafaz/mercury/model/ServerAuthType.java
@@ -1,0 +1,72 @@
+package it.skarafaz.mercury.model;
+
+import com.jcraft.jsch.KeyPair;
+
+public enum ServerAuthType {
+    DSA512, DSA1024, DSA2048, DSA4096, DSA8192,
+    ECDSA128, ECDSA256, ECDSA521,
+    RSA512, RSA1024, RSA2048, RSA4096, RSA8192;
+
+    public static String appendDefaultLength(String authType) {
+        authType = authType.toUpperCase();
+        if (authType.equals("DSA")) {
+            authType.concat("2048");
+        } else if (authType.equals("ECDSA")) {
+            authType.concat("256");
+        } else if (authType.equals("RSA")) {
+            authType.concat("2048");
+        }
+        return authType;
+    }
+
+    public int getKeyType() {
+        switch (this) {
+            case DSA512:
+            case DSA1024:
+            case DSA2048:
+            case DSA4096:
+            case DSA8192:
+                return KeyPair.DSA;
+            case ECDSA128:
+            case ECDSA256:
+            case ECDSA521:
+                return KeyPair.ECDSA;
+            case RSA512:
+            case RSA1024:
+            case RSA2048:
+            case RSA4096:
+            case RSA8192:
+                return KeyPair.RSA;
+            default:
+                throw new RuntimeException("invalid ServerAuthType");
+        }
+    }
+
+    public int getKeySize() {
+        switch (this) {
+            case DSA512:
+            case RSA512:
+                return 512;
+            case DSA1024:
+            case RSA1024:
+                return 1024;
+            case DSA2048:
+            case RSA2048:
+                return 2048;
+            case DSA4096:
+            case RSA4096:
+                return 4096;
+            case DSA8192:
+            case RSA8192:
+                return 8192;
+            case ECDSA128:
+                return 128;
+            case ECDSA256:
+                return 256;
+            case ECDSA521:
+                return 521;
+            default:
+                throw new RuntimeException("invalid ServerAuthType");
+        }
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SftpDownload.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SftpDownload.java
@@ -1,0 +1,114 @@
+package it.skarafaz.mercury.ssh;
+
+import android.os.Environment;
+
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.SftpException;
+import com.jcraft.jsch.SftpProgressMonitor;
+
+import org.greenrobot.eventbus.EventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import it.skarafaz.mercury.event.SftpDownloadEnd;
+import it.skarafaz.mercury.event.SftpDownloadProgress;
+import it.skarafaz.mercury.event.SftpDownloadStart;
+import it.skarafaz.mercury.model.Command;
+
+public class SftpDownload extends Thread {
+    private static final Logger logger = LoggerFactory.getLogger(SftpDownload.class);
+    protected static final int TIMEOUT = 10000;
+    protected static int nextId = 0;
+    protected int id;
+    protected SshServer server;
+    protected Command command;
+
+    protected File target;
+
+    public SftpDownload(SshServer server, Command command) {
+        this.id = nextId++;
+        this.server = server;
+        this.command = command;
+        this.target = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), new
+                File(command.getDownload()).getName());
+    }
+
+    @Override
+    public void run() {
+        if(beforeExecute()) {
+            SshCommandStatus status = execute();
+            afterExecute(status);
+        }
+    }
+
+    protected boolean beforeExecute() {
+        EventBus.getDefault().postSticky(new SftpDownloadStart(id, target));
+        return true;
+    }
+
+    private SshCommandStatus execute() {
+        SshCommandStatus status = server.connect();
+        if (status != SshCommandStatus.COMMAND_SUCCESSFUL) {
+            return status;
+        }
+
+        return download(command.getDownload(), target);
+    }
+
+    protected void afterExecute(SshCommandStatus status) {
+        EventBus.getDefault().postSticky(new SftpDownloadEnd(id, target, status, command.getView()));
+    }
+
+    protected SshCommandStatus download(String source, final File target) {
+        logger.debug(String.format("[%d] downloading file %s to loaction %s", getId(), source, target));
+        ChannelSftp channel = null;
+        try {
+            channel = (ChannelSftp) server.session.openChannel("sftp");
+            channel.connect();
+            channel.get(source, target.toString(), new SftpProgressMonitor() {
+                private long max;
+                private long count;
+                private long lastUpdate;
+                @Override
+                public void init(int op, String src, String dest, long max) {
+                    logger.trace(String.format("Init download op %d from %s to %s (%d bytes)", op, src, dest, max));
+                    this.max = max;
+                    this.count = 0;
+                    this.lastUpdate = 0;
+                    if (!command.getSilent()) {
+                        EventBus.getDefault().postSticky(new SftpDownloadProgress(id, target, 0, max));
+                    }
+                }
+
+                @Override
+                public boolean count(long count) {
+                    this.count += count;
+                    logger.trace(String.format("Downloaded %d of %d bytes", this.count, max));
+                    if (!command.getSilent() && System.currentTimeMillis() - lastUpdate > 100) {
+                        EventBus.getDefault().postSticky(new SftpDownloadProgress(id, target, this.count, max));
+                        lastUpdate = System.currentTimeMillis();
+                    }
+                    return true;
+                }
+
+                @Override
+                public void end() {
+                    logger.trace("Download finished");
+                }
+            }, ChannelSftp.OVERWRITE);
+            logger.debug(String.format("[%d] finished downloading file %s to loaction %s", getId(), source, target));
+            return SshCommandStatus.COMMAND_SUCCESSFUL;
+        } catch (JSchException | SftpException e) {
+            logger.debug(String.format("[%d] could not download file %s to loaction %s", getId(), source, target), e);
+            logger.error(e.getMessage().replace("\n", " "));
+            return SshCommandStatus.COMMUNICATION_ERROR;
+        } finally {
+            if (channel != null) {
+                channel.disconnect();
+            }
+        }
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SftpDownload.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SftpDownload.java
@@ -17,6 +17,7 @@ import it.skarafaz.mercury.event.SftpDownloadEnd;
 import it.skarafaz.mercury.event.SftpDownloadProgress;
 import it.skarafaz.mercury.event.SftpDownloadStart;
 import it.skarafaz.mercury.model.Command;
+import it.skarafaz.mercury.model.RegularCommand;
 
 public class SftpDownload extends Thread {
     private static final Logger logger = LoggerFactory.getLogger(SftpDownload.class);
@@ -24,11 +25,11 @@ public class SftpDownload extends Thread {
     protected static int nextId = 0;
     protected int id;
     protected SshServer server;
-    protected Command command;
+    protected RegularCommand command;
 
     protected File target;
 
-    public SftpDownload(SshServer server, Command command) {
+    public SftpDownload(SshServer server, RegularCommand command) {
         this.id = nextId++;
         this.server = server;
         this.command = command;

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommand.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommand.java
@@ -1,10 +1,7 @@
 package it.skarafaz.mercury.ssh;
 
 import com.jcraft.jsch.ChannelExec;
-import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
-import com.jcraft.jsch.UserInfo;
 
 import org.greenrobot.eventbus.EventBus;
 import org.slf4j.Logger;
@@ -12,7 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Properties;
 
 import it.skarafaz.mercury.event.SshCommandEnd;
 import it.skarafaz.mercury.event.SshCommandStart;
@@ -20,24 +16,21 @@ import it.skarafaz.mercury.event.SshCommandStart;
 public abstract class SshCommand extends Thread {
     protected static final int TIMEOUT = 10000;
     private static final Logger logger = LoggerFactory.getLogger(SshCommand.class);
-    protected JSch jsch;
-    protected Session session;
-    protected String host;
-    protected Integer port;
-    protected String user;
-    protected String password;
-    protected String sudoPath;
-    protected String nohupPath;
+    protected SshServer server;
     protected Boolean sudo;
     protected String cmd;
     protected Boolean confirm;
+    protected Boolean wait;
+    protected String output;
+    protected String error;
 
-    public SshCommand() {
-        this.jsch = new JSch();
+    public SshCommand(SshServer server) {
+        this.server = server;
     }
 
     @Override
     public void run() {
+        output = error = null;
         if(beforeExecute()) {
             SshCommandStatus status = execute();
             afterExecute(status);
@@ -50,57 +43,24 @@ public abstract class SshCommand extends Thread {
     }
 
     private SshCommandStatus execute() {
-        SshCommandStatus status = SshCommandStatus.COMMAND_SENT;
-
-        if (initConnection()) {
-            if (connect()) {
-                if (!send(formatCmd(cmd))) {
-                    status = SshCommandStatus.EXECUTION_FAILED;
-                }
-                disconnect();
-            } else {
-                status = SshCommandStatus.CONNECTION_FAILED;
-            }
-        } else {
-            status = SshCommandStatus.CONNECTION_INIT_ERROR;
+        SshCommandStatus status = server.connect();
+        if (status != SshCommandStatus.COMMAND_SUCCESSFUL) {
+            return status;
         }
-
-        return status;
+        return send(formatCmd(cmd));
     }
 
     protected void afterExecute(SshCommandStatus status) {
         EventBus.getDefault().postSticky(new SshCommandEnd(status));
     }
 
-    protected boolean initConnection() {
-        return true;
-    }
-
-    protected boolean connect() {
-        boolean success = true;
-        try {
-            session = jsch.getSession(user, host, port);
-
-            session.setUserInfo(getUserInfo());
-            session.setConfig(getSessionConfig());
-            session.setPassword(password);
-
-            session.connect(TIMEOUT);
-        } catch (JSchException e) {
-            logger.error(e.getMessage().replace("\n", " "));
-            success = false;
-        }
-        return success;
-    }
-
-    protected boolean send(String cmd) {
-        logger.debug("sending command: {}", cmd);
+    protected SshCommandStatus send(String cmd) {
+        logger.debug(String.format("[%d] sending command: %s", getId(), cmd));
 
         ChannelExec channel = null;
 
-        boolean success = true;
         try {
-            channel = (ChannelExec) session.openChannel("exec");
+            channel = (ChannelExec) server.session.openChannel("exec");
             channel.setCommand(cmd);
             channel.setInputStream(null);
 
@@ -108,32 +68,66 @@ public abstract class SshCommand extends Thread {
             InputStream stderr = channel.getErrStream();
 
             channel.connect(TIMEOUT);
-            success = waitForChannelClosed(channel, stdout, stderr);
+            return waitForChannelClosed(channel, stdout, stderr);
         } catch (IOException | JSchException e) {
             logger.error(e.getMessage().replace("\n", " "));
-            success = false;
+            return SshCommandStatus.COMMUNICATION_ERROR;
         } finally {
             if (channel != null) {
                 channel.disconnect();
             }
         }
-        return success;
     }
 
-    protected boolean waitForChannelClosed(ChannelExec channel, InputStream stdout, InputStream stderr) {
-        return true;
-    }
+    protected SshCommandStatus waitForChannelClosed(ChannelExec channel, InputStream stdout,
+                                                    InputStream stderr) throws IOException {
+        if (!wait) return SshCommandStatus.COMMAND_SENT;
+        long start = System.currentTimeMillis();
+        boolean success = false;
+        byte buf[] = new byte[1024];
+        int len;
+        StringBuilder sbout = new StringBuilder();
+        StringBuilder sberr = new StringBuilder();
 
-    protected void disconnect() {
-        session.disconnect();
-    }
-
-    protected UserInfo getUserInfo() {
-        return null;
-    }
-
-    protected Properties getSessionConfig() {
-        return new Properties();
+        while (true) {
+            if (stdout.available() > 0) {
+                len = stdout.read(buf, 0, 1024);
+                if (len < 0) throw new IOException("stdout");
+                sbout.append(new String(buf, 0, len, "UTF-8"));
+                logger.trace(String.format("[%d] stdout available = %d / read %d",
+                        getId(), stdout.available(), sbout.length()));
+            }
+            if (stderr.available() > 0) {
+                len = stderr.read(buf, 0, 1024);
+                if (len < 0) throw new IOException("stderr");
+                sberr.append(new String(buf, 0, len, "UTF-8"));
+                logger.trace(String.format("[%d] stderr available = %d / read %d",
+                        getId(), stderr.available(), sberr.length()));
+            }
+            if (channel.isClosed()) {
+                if (stdout.available() > 0 || stderr.available() > 0) continue;
+                break;
+            }
+            if (System.currentTimeMillis() - start > TIMEOUT) {
+                logger.error(String.format("Timeout after %d milliseconds", TIMEOUT));
+                return SshCommandStatus.COMMAND_TIMEOUT;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (Exception ee) {
+                logger.debug(ee.getMessage().replace("\n", " "));
+            }
+        }
+        output = sbout.toString();
+        error = sberr.toString();
+        logger.debug(String.format("[%d] exitcode = %d", getId(), channel.getExitStatus()));
+        logger.debug(String.format("[%d] stdout = %s", getId(), output.replace("\n", " ")));
+        logger.debug(String.format("[%d] stderr = %s", getId(), error.replace("\n", " ")));
+        if (channel.getExitStatus() == 0) {
+            return SshCommandStatus.COMMAND_SUCCESSFUL;
+        } else {
+            return SshCommandStatus.EXECUTION_FAILED;
+        }
     }
 
     protected String formatCmd(String cmd) {

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommand.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommand.java
@@ -24,7 +24,6 @@ public abstract class SshCommand extends Thread {
     protected Boolean confirm;
     protected Boolean wait;
     protected Boolean background;
-    protected Boolean multiple;
     protected Boolean silent;
     protected String output;
     protected String error;

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
@@ -10,16 +10,20 @@ import java.io.IOException;
 
 import it.skarafaz.mercury.event.SshCommandPubKeyInput;
 import it.skarafaz.mercury.manager.SshManager;
+import it.skarafaz.mercury.model.Command;
 
 public class SshCommandPubKey extends SshCommand {
     private static final Logger logger = LoggerFactory.getLogger(SshCommandPubKey.class);
     private String pubKey;
 
     public SshCommandPubKey(SshServer server) {
-        super(server);
+        super(server, new Command());
         sudo = false;
         confirm = false;
         wait = true;
+        background = false;
+        multiple = false;
+        silent = false;
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
@@ -22,7 +22,6 @@ public class SshCommandPubKey extends SshCommand {
         confirm = false;
         wait = true;
         background = false;
-        multiple = false;
         silent = false;
     }
 

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
@@ -2,22 +2,19 @@ package it.skarafaz.mercury.ssh;
 
 import com.jcraft.jsch.JSchException;
 
-import org.greenrobot.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import it.skarafaz.mercury.event.SshCommandPubKeyInput;
 import it.skarafaz.mercury.manager.SshManager;
-import it.skarafaz.mercury.model.Command;
 
 public class SshCommandPubKey extends SshCommand {
     private static final Logger logger = LoggerFactory.getLogger(SshCommandPubKey.class);
     private String pubKey;
 
     public SshCommandPubKey(SshServer server) {
-        super(server, new Command());
+        super(server, null);
         sudo = false;
         confirm = false;
         wait = true;
@@ -33,29 +30,7 @@ public class SshCommandPubKey extends SshCommand {
             logger.error(e.getMessage().replace("\n", " "));
             return false;
         }
-        // Use user@host:port from server
-        /*SshCommandDrop<String> drop = new SshCommandDrop<>();
-        EventBus.getDefault().postSticky(new SshCommandPubKeyInput(drop));
-
-        String input = drop.take();
-        if (input == null) {
-            return false;
-        }
-        setHostPortUser(input);*/
-
         return super.beforeExecute();
-    }
-
-    private void setHostPortUser(String input) {
-        String[] sInput = input.split("@");
-        String left = sInput[0];
-        String right = sInput[1];
-
-        String[] sRight = right.split(":");
-
-        server.host = sRight[0];
-        server.port = sRight.length > 1 ? Integer.valueOf(sRight[1]) : 22;
-        server.user = left;
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandPubKey.java
@@ -15,8 +15,8 @@ public class SshCommandPubKey extends SshCommand {
     private static final Logger logger = LoggerFactory.getLogger(SshCommandPubKey.class);
     private String pubKey;
 
-    public SshCommandPubKey() {
-        super(new SshServer());
+    public SshCommandPubKey(SshServer server) {
+        super(server);
         sudo = false;
         confirm = false;
         wait = true;
@@ -25,19 +25,20 @@ public class SshCommandPubKey extends SshCommand {
     @Override
     protected boolean beforeExecute() {
         try {
-            pubKey = SshManager.getInstance().getPublicKeyContent();
+            pubKey = SshManager.getInstance().getPublicKeyContent(server.authType);
         } catch (IOException | JSchException e) {
             logger.error(e.getMessage().replace("\n", " "));
             return false;
         }
-        SshCommandDrop<String> drop = new SshCommandDrop<>();
+        // Use user@host:port from server
+        /*SshCommandDrop<String> drop = new SshCommandDrop<>();
         EventBus.getDefault().postSticky(new SshCommandPubKeyInput(drop));
 
         String input = drop.take();
         if (input == null) {
             return false;
         }
-        setHostPortUser(input);
+        setHostPortUser(input);*/
 
         return super.beforeExecute();
     }

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
@@ -1,14 +1,9 @@
 package it.skarafaz.mercury.ssh;
 
-import org.greenrobot.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import it.skarafaz.mercury.MercuryApplication;
-import it.skarafaz.mercury.R;
-import it.skarafaz.mercury.event.SshCommandConfirm;
-import it.skarafaz.mercury.event.SshCommandPassword;
-import it.skarafaz.mercury.model.Command;
+import it.skarafaz.mercury.model.RegularCommand;
 
 public class SshCommandRegular extends SshCommand {
     private static final Logger logger = LoggerFactory.getLogger(SshCommandRegular.class);
@@ -16,7 +11,7 @@ public class SshCommandRegular extends SshCommand {
     private String download;
     private Boolean view;
 
-    public SshCommandRegular(SshServer server, Command command) {
+    public SshCommandRegular(SshServer server, RegularCommand command) {
         super(server, command);
 
         this.sudo = command.getSudo();
@@ -30,47 +25,11 @@ public class SshCommandRegular extends SshCommand {
     }
 
     @Override
-    protected boolean beforeExecute() {
-        if (confirm) {
-            SshCommandDrop<Boolean> drop = new SshCommandDrop<>();
-            EventBus.getDefault().postSticky(new SshCommandConfirm(cmd, drop));
-
-            if (!drop.take()) {
-                return false;
-            }
-        }
-
-        if (sudo && server.password == null) {
-            SshCommandDrop<String> drop = new SshCommandDrop<>();
-            String message = MercuryApplication.getContext().getString(R.string.type_sudo_password,
-                    server.formatServerLabel());
-            EventBus.getDefault().postSticky(new SshCommandPassword(message, drop));
-
-            server.password = drop.take();
-            if (server.password == null) {
-                return false;
-            }
-        }
-
-        return super.beforeExecute();
-    }
-
-    @Override
     protected void afterExecute(SshCommandStatus status) {
         super.afterExecute(status);
         if (download != null && (status == SshCommandStatus.COMMAND_SENT || status == SshCommandStatus
                 .COMMAND_SUCCESSFUL)) {
-            (new SftpDownload(server, command)).start();
-        }
-    }
-
-    @Override
-    protected String formatCmd(String cmd) {
-        if (sudo) {
-            return String.format("echo %s | %s -S -p '' %s %s", server.password,
-                    server.sudoPath, server.nohupPath, cmd);
-        } else {
-            return String.format("%s %s", server.nohupPath, cmd);
+            (new SftpDownload(server, (RegularCommand) command)).start();
         }
     }
 }

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
@@ -13,16 +13,20 @@ import it.skarafaz.mercury.model.Command;
 public class SshCommandRegular extends SshCommand {
     private static final Logger logger = LoggerFactory.getLogger(SshCommandRegular.class);
 
+    private String download;
+    private Boolean view;
+
     public SshCommandRegular(SshServer server, Command command) {
         super(server, command);
 
         this.sudo = command.getSudo();
         this.cmd = command.getCmd();
+        this.download = command.getDownload();
         this.confirm = command.getConfirm();
         this.wait = command.getWait();
         this.background = command.getBackground();
-        this.multiple = command.getMultiple();
         this.silent = command.getSilent();
+        this.view = command.getView();
     }
 
     @Override
@@ -49,6 +53,15 @@ public class SshCommandRegular extends SshCommand {
         }
 
         return super.beforeExecute();
+    }
+
+    @Override
+    protected void afterExecute(SshCommandStatus status) {
+        super.afterExecute(status);
+        if (download != null && (status == SshCommandStatus.COMMAND_SENT || status == SshCommandStatus
+                .COMMAND_SUCCESSFUL)) {
+            (new SftpDownload(server, command)).start();
+        }
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
@@ -1,37 +1,25 @@
 package it.skarafaz.mercury.ssh;
 
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.UserInfo;
-
 import org.greenrobot.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Properties;
 
 import it.skarafaz.mercury.MercuryApplication;
 import it.skarafaz.mercury.R;
 import it.skarafaz.mercury.event.SshCommandConfirm;
 import it.skarafaz.mercury.event.SshCommandPassword;
-import it.skarafaz.mercury.manager.SshManager;
 import it.skarafaz.mercury.model.Command;
 
 public class SshCommandRegular extends SshCommand {
     private static final Logger logger = LoggerFactory.getLogger(SshCommandRegular.class);
 
-    public SshCommandRegular(Command command) {
-        super();
+    public SshCommandRegular(SshServer server, Command command) {
+        super(server);
 
-        this.host = command.getServer().getHost();
-        this.port = command.getServer().getPort();
-        this.user = command.getServer().getUser();
-        this.password = command.getServer().getPassword();
-        this.sudoPath = command.getServer().getSudoPath();
-        this.nohupPath = command.getServer().getNohupPath();
         this.sudo = command.getSudo();
         this.cmd = command.getCmd();
         this.confirm = command.getConfirm();
+        this.wait = command.getWait();
     }
 
     @Override
@@ -45,13 +33,14 @@ public class SshCommandRegular extends SshCommand {
             }
         }
 
-        if (sudo && password == null) {
+        if (sudo && server.password == null) {
             SshCommandDrop<String> drop = new SshCommandDrop<>();
-            String message = MercuryApplication.getContext().getString(R.string.type_sudo_password, formatServerLabel());
+            String message = MercuryApplication.getContext().getString(R.string.type_sudo_password,
+                    server.formatServerLabel());
             EventBus.getDefault().postSticky(new SshCommandPassword(message, drop));
 
-            password = drop.take();
-            if (password == null) {
+            server.password = drop.take();
+            if (server.password == null) {
                 return false;
             }
         }
@@ -60,45 +49,12 @@ public class SshCommandRegular extends SshCommand {
     }
 
     @Override
-    protected boolean initConnection() {
-        boolean success = true;
-        try {
-            jsch.setKnownHosts(SshManager.getInstance().getKnownHosts().getAbsolutePath());
-            jsch.addIdentity(SshManager.getInstance().getPrivateKey().getAbsolutePath());
-        } catch (IOException | JSchException e) {
-            logger.error(e.getMessage().replace("\n", " "));
-            success = false;
-        }
-        return success;
-    }
-
-    @Override
-    protected UserInfo getUserInfo() {
-        return new SshCommandUserInfo();
-    }
-
-    @Override
-    protected Properties getSessionConfig() {
-        Properties config = super.getSessionConfig();
-        config.put("PreferredAuthentications", "publickey,password");
-        config.put("MaxAuthTries", "1");
-        return config;
-    }
-
-    @Override
     protected String formatCmd(String cmd) {
         if (sudo) {
-            return String.format("echo %s | %s -S -p '' %s %s > /dev/null 2>&1", password, sudoPath, nohupPath, cmd);
+            return String.format("echo %s | %s -S -p '' %s %s", server.password,
+                    server.sudoPath, server.nohupPath, cmd);
         } else {
-            return String.format("%s %s > /dev/null 2>&1", nohupPath, cmd);
+            return String.format("%s %s", server.nohupPath, cmd);
         }
-    }
-
-    private String formatServerLabel() {
-        StringBuilder sb = new StringBuilder(String.format("%s@%s", user, host));
-        if (port != 22) {
-            sb.append(String.format(":%d", port));
-        }
-        return sb.toString();
     }
 }

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRegular.java
@@ -14,12 +14,15 @@ public class SshCommandRegular extends SshCommand {
     private static final Logger logger = LoggerFactory.getLogger(SshCommandRegular.class);
 
     public SshCommandRegular(SshServer server, Command command) {
-        super(server);
+        super(server, command);
 
         this.sudo = command.getSudo();
         this.cmd = command.getCmd();
         this.confirm = command.getConfirm();
         this.wait = command.getWait();
+        this.background = command.getBackground();
+        this.multiple = command.getMultiple();
+        this.silent = command.getSilent();
     }
 
     @Override

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRulerGet.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRulerGet.java
@@ -1,0 +1,37 @@
+package it.skarafaz.mercury.ssh;
+
+import org.greenrobot.eventbus.EventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import it.skarafaz.mercury.event.SshCommandRulerUpdate;
+import it.skarafaz.mercury.model.Ruler;
+
+public class SshCommandRulerGet extends SshCommand {
+    private static final Logger logger = LoggerFactory.getLogger(SshCommandRulerGet.class);
+
+    public SshCommandRulerGet(SshServer server, Ruler ruler) {
+        super(server, ruler);
+
+        this.sudo = ruler.getSudo();
+        this.cmd = ruler.getGetCmd();
+        this.confirm = ruler.getConfirm();
+        this.wait = true;
+        this.background = ruler.getBackground();
+        this.silent = ruler.getSilent();
+    }
+
+    @Override
+    protected void afterExecute(SshCommandStatus status) {
+        if (status == SshCommandStatus.COMMAND_SENT || status == SshCommandStatus.COMMAND_SUCCESSFUL) {
+            try {
+                ((Ruler) command).setValue(Integer.valueOf(output.split("\n")[0]));
+                EventBus.getDefault().postSticky(new SshCommandRulerUpdate());
+            } catch (NumberFormatException e) {
+                logger.error(String.format("Could not parse value: %s", e));
+                status = SshCommandStatus.EXECUTION_FAILED;
+            }
+        }
+        super.afterExecute(status);
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRulerSet.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandRulerSet.java
@@ -1,0 +1,27 @@
+package it.skarafaz.mercury.ssh;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import it.skarafaz.mercury.model.Ruler;
+
+public class SshCommandRulerSet extends SshCommand {
+    private static final Logger logger = LoggerFactory.getLogger(SshCommandRulerSet.class);
+
+    public SshCommandRulerSet(SshServer server, Ruler ruler) {
+        super(server, ruler);
+
+        this.sudo = ruler.getSudo();
+        this.cmd = ruler.getSetCmd();
+        this.confirm = ruler.getConfirm();
+        this.wait = ruler.getWait();
+        this.background = ruler.getBackground();
+        this.silent = ruler.getSilent();
+    }
+
+    @Override
+    protected boolean beforeExecute() {
+        setEnv("VALUE", String.valueOf(((Ruler) command).getValue()));
+        return super.beforeExecute();
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandStatus.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandStatus.java
@@ -5,13 +5,14 @@ import it.skarafaz.mercury.R;
 public enum SshCommandStatus {
     CONNECTION_INIT_ERROR(R.string.connection_init_error),
     CONNECTION_FAILED(R.string.connection_failed),
-    COMMUNICATION_ERROR(R.string.communication_error),
     EXECUTION_FAILED(R.string.execution_failed),
+    COMMUNICATION_ERROR(R.string.communication_error),
     COMMAND_TIMEOUT(R.string.command_timeout),
-    COMMAND_SUCCESSFUL(R.string.command_successful),
-    COMMAND_SENT(R.string.command_sent);
+    COMMAND_SENT(R.string.command_sent),
+    COMMAND_SUCCESSFUL(R.string.command_successful);
 
     private int message;
+    private String output;
 
     SshCommandStatus(int message) {
         this.message = message;

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandStatus.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshCommandStatus.java
@@ -5,7 +5,10 @@ import it.skarafaz.mercury.R;
 public enum SshCommandStatus {
     CONNECTION_INIT_ERROR(R.string.connection_init_error),
     CONNECTION_FAILED(R.string.connection_failed),
+    COMMUNICATION_ERROR(R.string.communication_error),
     EXECUTION_FAILED(R.string.execution_failed),
+    COMMAND_TIMEOUT(R.string.command_timeout),
+    COMMAND_SUCCESSFUL(R.string.command_successful),
     COMMAND_SENT(R.string.command_sent);
 
     private int message;

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshServer.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshServer.java
@@ -190,7 +190,7 @@ public class SshServer extends Thread {
                     }
                 }
             });
-        } catch (IOException | JSchException e) {
+        } catch (IOException | JSchException | RuntimeException e) {
             logger.error(e.getMessage().replace("\n", " "));
             success = false;
         }
@@ -208,7 +208,7 @@ public class SshServer extends Thread {
             session.setPassword(password);
 
             session.connect(TIMEOUT);
-        } catch (JSchException e) {
+        } catch (JSchException | RuntimeException e) {
             logger.error(e.getMessage().replace("\n", " "));
             success = false;
         }

--- a/app/src/main/java/it/skarafaz/mercury/ssh/SshServer.java
+++ b/app/src/main/java/it/skarafaz/mercury/ssh/SshServer.java
@@ -1,0 +1,146 @@
+package it.skarafaz.mercury.ssh;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UserInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import it.skarafaz.mercury.manager.SshManager;
+import it.skarafaz.mercury.model.Server;
+
+public class SshServer extends Thread {
+    protected static final int TIMEOUT = 10000;
+    private static final Logger logger = LoggerFactory.getLogger(SshServer.class);
+
+    protected JSch jsch;
+    protected Session session;
+
+    protected String host;
+    protected Integer port;
+    protected String user;
+    protected String password;
+    protected String sudoPath;
+    protected String nohupPath;
+
+
+    public SshServer() {
+        this.jsch = new JSch();
+    }
+
+    public SshServer(Server server) {
+        this();
+
+        host = server.getHost();
+        port = server.getPort();
+        user = server.getUser();
+        password = server.getPassword();
+        sudoPath = server.getSudoPath();
+        nohupPath = server.getNohupPath();
+    }
+
+    synchronized public SshCommandStatus connect() {
+        if (!isConnected()) {
+            if (!initConnection()) {
+                return SshCommandStatus.CONNECTION_INIT_ERROR;
+            }
+            if (!getSession()) {
+                return SshCommandStatus.CONNECTION_FAILED;
+            }
+        }
+        return SshCommandStatus.COMMAND_SUCCESSFUL;
+    }
+
+    public void disconnect() {
+        logger.debug(String.format("Disconnecting from server %s", formatServerLabel()));
+        if (isConnected()) {
+            session.disconnect();
+        }
+    }
+
+    protected boolean isConnected() {
+        return session != null && session.isConnected();
+    }
+
+    protected boolean initConnection() {
+        boolean success = true;
+        try {
+            jsch.setKnownHosts(SshManager.getInstance().getKnownHosts().getAbsolutePath());
+            jsch.addIdentity(SshManager.getInstance().getPrivateKey().getAbsolutePath());
+            jsch.setLogger(new com.jcraft.jsch.Logger() {
+                @Override
+                public boolean isEnabled(int level) {
+                    return true;
+                }
+
+                @Override
+                public void log(int level, String message) {
+                    message = String.format("JSch: %s", message);
+                    switch (level) {
+                        case com.jcraft.jsch.Logger.FATAL:
+                            logger.error(message);
+                            break;
+                        case com.jcraft.jsch.Logger.ERROR:
+                            logger.warn(message);
+                            break;
+                        case com.jcraft.jsch.Logger.WARN:
+                            logger.info(message);
+                            break;
+                        case com.jcraft.jsch.Logger.INFO:
+                            logger.debug(message);
+                            break;
+                        case com.jcraft.jsch.Logger.DEBUG:
+                            logger.trace(message);
+                            break;
+                    }
+                }
+            });
+        } catch (IOException | JSchException e) {
+            logger.error(e.getMessage().replace("\n", " "));
+            success = false;
+        }
+        return success;
+    }
+
+    protected boolean getSession() {
+        boolean success = true;
+        try {
+            logger.debug(String.format("Connecting to server %s", formatServerLabel()));
+            session = jsch.getSession(user, host, port);
+
+            session.setUserInfo(getUserInfo());
+            session.setConfig(getSessionConfig());
+            session.setPassword(password);
+
+            session.connect(TIMEOUT);
+        } catch (JSchException e) {
+            logger.error(e.getMessage().replace("\n", " "));
+            success = false;
+        }
+        return success;
+    }
+
+    protected UserInfo getUserInfo() {
+        return new SshCommandUserInfo();
+    }
+
+    protected Properties getSessionConfig() {
+        Properties config = new Properties();
+        config.put("PreferredAuthentications", "publickey,password");
+        config.put("MaxAuthTries", "1");
+        return config;
+    }
+
+    public String formatServerLabel() {
+        StringBuilder sb = new StringBuilder(String.format("%s@%s", user, host));
+        if (port != 22) {
+            sb.append(String.format(":%d", port));
+        }
+        return sb.toString();
+    }
+}

--- a/app/src/main/java/it/skarafaz/mercury/view/TextProgressBar.java
+++ b/app/src/main/java/it/skarafaz/mercury/view/TextProgressBar.java
@@ -1,0 +1,60 @@
+package it.skarafaz.mercury.view;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.util.TypedValue;
+import android.widget.ProgressBar;
+
+public class TextProgressBar extends ProgressBar {
+    private String text;
+    private Paint textPaint;
+
+    public TextProgressBar(Context context) {
+        super(context);
+        text = "";
+        textPaint = new Paint();
+    }
+
+    public TextProgressBar(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        text = "";
+        textPaint = new Paint();
+    }
+
+    public TextProgressBar(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        text = "";
+        textPaint = new Paint();
+    }
+
+    @Override
+    protected synchronized void onDraw(Canvas canvas) {
+        // First draw the regular progress bar, then custom draw our text
+        super.onDraw(canvas);
+        Rect bounds = new Rect();
+        textPaint.getTextBounds(text, 0, text.length(), bounds);
+        int x = getWidth() / 2 - bounds.centerX();
+        int y = getHeight() / 2 - bounds.centerY();
+        canvas.drawText(text, x, y, textPaint);
+    }
+
+    public synchronized void setText(String text) {
+        this.text = text;
+        drawableStateChanged();
+    }
+
+    public void setTextColor(int color) {
+        textPaint.setColor(color);
+        drawableStateChanged();
+    }
+
+    public void setTextSize(float size) {
+        textPaint.setTextSize(size);
+        drawableStateChanged();
+    }
+}

--- a/app/src/main/res/layout/command_list_item.xml
+++ b/app/src/main/res/layout/command_list_item.xml
@@ -27,6 +27,16 @@
         android:maxLines="1"
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="16sp" />
+    <SeekBar
+        android:id="@+id/ruler"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="56dp"
+        android:layout_toRightOf="@+id/icon"
+        android:layout_toEndOf="@+id/icon"
+        android:visibility="invisible" />
 
     <it.skarafaz.mercury.view.TextProgressBar
         style="?android:attr/progressBarStyleSmall"

--- a/app/src/main/res/layout/command_list_item.xml
+++ b/app/src/main/res/layout/command_list_item.xml
@@ -28,6 +28,15 @@
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="16sp" />
 
+    <it.skarafaz.mercury.view.TextProgressBar
+        style="?android:attr/progressBarStyleSmall"
+        android:id="@+id/progress"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:layout_toLeftOf="@+id/info"
+        android:layout_toStartOf="@+id/info"
+        android:visibility="invisible" />
+
     <ImageView
         android:id="@+id/info"
         android:layout_width="48dp"

--- a/app/src/main/res/layout/command_list_item.xml
+++ b/app/src/main/res/layout/command_list_item.xml
@@ -5,6 +5,15 @@
     android:layout_height="56dp"
     android:background="?android:attr/selectableItemBackground">
 
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:layout_centerVertical="true"
+        android:background="@drawable/ripple"
+        android:scaleType="center"
+        android:visibility="invisible" />
+
     <TextView
         android:id="@+id/name"
         android:layout_width="match_parent"
@@ -12,8 +21,10 @@
         android:layout_centerVertical="true"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="56dp"
+        android:layout_toRightOf="@+id/icon"
+        android:layout_toEndOf="@+id/icon"
         android:ellipsize="end"
-        android:singleLine="true"
+        android:maxLines="1"
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="16sp" />
 
@@ -21,6 +32,7 @@
         android:id="@+id/info"
         android:layout_width="48dp"
         android:layout_height="48dp"
+        android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:layout_marginRight="4dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="empty_config_dir">No config files found in\n%s</string>
     <string name="empty_log">Log file is empty</string>
     <string name="execution_failed">Command execution failed, please see log for details</string>
-    <string name="export_public_key_error">Cannot export public key, plesase see log for details</string>
+    <string name="export_public_key_error">Cannot export public key, please see log for details</string>
     <string name="export_public_key_permission">Mercury-SSH requires STORAGE permission to export the public key to sdcard</string>
     <string name="export_public_key_success">Public key exported to\n%s</string>
     <string name="exporting_public_key">Exporting public key&#8230;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,13 @@
     <string name="connection_init_error">An error occurred during connection initialization, please see log for details</string>
     <string name="connection_string_hint">user@host:port</string>
     <string name="connection_string_message">Type connection string for target server</string>
+    <string name="download_failed">Download failed</string>
+    <string name="download_failed_file">Download of %s could not be completed</string>
+    <string name="download_succeeded">Download succeeded</string>
+    <string name="download_succeeded_file">%s downloaded</string>
+    <string name="downloading">Downloading&#8230;</string>
+    <string name="downloading_starting">Start downloading %s</string>
+    <string name="downloading_percent">%1$d%% Downloading %2$s (%3$s of %4$s)</string>
     <string name="empty_config_dir">No config files found in\n%s</string>
     <string name="empty_log">Log file is empty</string>
     <string name="execution_failed">Command execution failed, please see log for details</string>
@@ -42,7 +49,8 @@
     <string name="exporting_public_key">Exporting public key&#8230;</string>
     <string name="load_config_files_error">One or more config files did not pass the validity check, please see log for details</string>
     <string name="load_config_files_permission">Mercury-SSH requires STORAGE permission to read config files</string>
-    <string name="no_commands">No commands defined\nfor this server</string>
+    <string name="no_commands">No entries defined\nfor this server</string>
+    <string name="no_handler">No handler for this type of file.</string>
     <string name="password">Password</string>
     <string name="send_publick_key">Send public key</string>
     <string name="sending_command">Sending command&#8230;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,9 @@
     <string name="cannot_read_ext_storage">Cannot read external storage</string>
     <string name="cannot_write_ext_storage">Cannot write to external storage</string>
     <string name="command_sent">Command sent!</string>
+    <string name="command_successful">Command executed successfully!</string>
+    <string name="command_timeout">Command timed out</string>
+    <string name="communication_error">Communication error</string>
     <string name="confirm_exec">Confirm execution?</string>
     <string name="connection_failed">Failed to connect to server, please see log for details</string>
     <string name="connection_init_error">An error occurred during connection initialization, please see log for details</string>


### PR DESCRIPTION
Command icons are specified using optional "icon" property in json file.
If "icon" property is not specified, the old layout without icon is used.
Icon files should be placed in Mercury-SSH folder.

Currently icon size is fixed (96x96 pixels).
Personally I like symbolic icons from Adwaita theme with inverted
colors.

From the second command executed for a server, the execution will be
faster because the SSH session is reused (only a new exec channel is
opened).
From the second command on, no password has to be entered (if at all).
The SSH session is only kept alive as long as the server fragment is shown
(disconnect in onPause).
A new property "wait" is introduced. If true, the exec channel will be
kept open until the command finishes. The displayed toast will depend
on the exit code of the command.

Example configuration snippet:

>       "commands" : [
>                {
>                        "name" : "Reboot system",
>                        "icon" : "system-shutdown-symbolic.png",
>                        "cmd" : "systemctl reboot",
>                        "confirm" : true,
>                        "wait" : true
>                }
>       ]

Adds server properties "mdnsname" and "mdnstype". "mdnsname" may be
specified instead of or additionally to "host"(/"port"). "mdnstype"
defaults to "_ssh._tcp". If mDNS resolve is successful, host and port
of the mDNS service are used. If unsuccessful or no "mdnsname" is
specified, use "host"(/"port") property for connection (specified as
IP address or classic DNS name).

Example:
>     {
>             "name" : "My laptop",
>             "host" : "192.168.0.10",
>             "port" : 22,
>             "mdnsname" : "server",
>             "mdnstype" : "_ssh._tcp",
>             "user" : "guest",
>             "commands" : [
>                     ...
>             ]
>     }

This feature is especially useful if you use dynamic adresses (e.g.
assigned by DHCP) and DNS resolution fails (DDNS update by DHCP is not
configured).

Remark: By default, the mDNS domain .local is used. Specifying
"server.local" as "mdnsname" didn't work for me. Use the following for
debugging:
> avahi-browse -vrt _ssh._tcp